### PR TITLE
ci: add basic CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+on:
+  push:
+    branches: [master]
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r requirements.txt
+      - run: python -c "import flask; print('Dependencies OK')"


### PR DESCRIPTION
Adds a GitHub Actions CI workflow that triggers on push to master and on pull requests. The workflow sets up Python 3.12, installs dependencies from requirements.txt, and verifies Flask can be imported. No test suite exists yet so this workflow focuses on dependency resolution and basic smoke testing.