### PR TITLE
feat(chemistry): recipe comparison API endpoint + batch cone support

### DIFF
--- a/core/chemistry/__init__.py
+++ b/core/chemistry/__init__.py
@@ -11,6 +11,7 @@ from .compatibility import CompatibilityResult, CompatibilityAnalyzer
 from .batch import BatchAnalyzer
 from .defects import DefectAnalysis, DefectPredictor, predict_defects
 from .substitutions import SubstitutionResult, SubstitutionEngine, suggest_substitutions
+from .compare import RecipeComparison, RecipeComparator, compare_recipes
 
 __all__ = [
     'Material',
@@ -31,4 +32,7 @@ __all__ = [
     'SubstitutionResult',
     'SubstitutionEngine',
     'suggest_substitutions',
+    'RecipeComparison',
+    'RecipeComparator',
+    'compare_recipes',
 ]

--- a/core/chemistry/batch.py
+++ b/core/chemistry/batch.py
@@ -64,9 +64,10 @@ def calculate_batch(recipe: Union[Dict[str, float], str], batch_size_grams: floa
 class BatchAnalyzer:
     """Batch UMF and compatibility analysis across all glazes and combinations."""
 
-    def __init__(self, db_path: str, user_id: Optional[str] = None):
+    def __init__(self, db_path: str, user_id: Optional[str] = None, cone: Optional[int] = None):
         self.db_path = db_path
         self.user_id = user_id
+        self.cone = cone
         self.umf_analyzer = UMFAnalyzer()
         self.compat_analyzer = CompatibilityAnalyzer()
 
@@ -97,7 +98,7 @@ class BatchAnalyzer:
                     glazes[name] = {'success': False, 'error': 'No recipe available'}
                     continue
 
-                umf = calculate_umf(recipe)
+                umf = calculate_umf(recipe, cone=self.cone)
                 glazes[name] = umf.to_dict()
 
         except Exception as e:
@@ -140,6 +141,7 @@ class BatchAnalyzer:
                     top_recipe=top_recipe,
                     base_name=base_name or '',
                     top_name=top_name or '',
+                    cone=self.cone,
                 )
                 results[combo_id] = compat.to_dict()
 

--- a/core/chemistry/compare.py
+++ b/core/chemistry/compare.py
@@ -1,0 +1,250 @@
+"""Recipe comparison — show chemical differences between two glaze recipes.
+
+Helps potters understand what changed when modifying a recipe,
+or compare a tested glaze to a target formula.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from .umf import calculate_umf, UMFResult
+
+
+@dataclass
+class RecipeDifference:
+    """A single difference between two recipes."""
+    category: str  # 'oxide', 'ratio', 'material', 'surface', 'cte'
+    metric: str
+    base_value: Optional[float]
+    top_value: Optional[float]
+    delta: Optional[float]
+    delta_percent: Optional[float]
+    interpretation: str
+
+
+@dataclass
+class RecipeComparison:
+    """Full comparison between two glaze recipes."""
+    success: bool
+    base_name: str = ''
+    top_name: str = ''
+    differences: List[RecipeDifference] = field(default_factory=list)
+    base_umf: Optional[Dict] = None
+    top_umf: Optional[Dict] = None
+    error: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {
+            'success': self.success,
+            'base_name': self.base_name,
+            'top_name': self.top_name,
+            'differences': [
+                {
+                    'category': d.category,
+                    'metric': d.metric,
+                    'base_value': d.base_value,
+                    'top_value': d.top_value,
+                    'delta': d.delta,
+                    'delta_percent': d.delta_percent,
+                    'interpretation': d.interpretation,
+                }
+                for d in self.differences
+            ],
+            'base_umf': self.base_umf,
+            'top_umf': self.top_umf,
+            'error': self.error,
+        }
+
+
+class RecipeComparator:
+    """Compare two glaze recipes chemically."""
+
+    def compare(self, recipe_a: str, recipe_b: str,
+                name_a: str = 'Recipe A', name_b: str = 'Recipe B',
+                cone: Optional[int] = None) -> RecipeComparison:
+        """Compare two recipes and highlight chemical differences.
+
+        Args:
+            recipe_a: First recipe string
+            recipe_b: Second recipe string
+            name_a: Name for first recipe
+            name_b: Name for second recipe
+            cone: Target cone for analysis
+
+        Returns:
+            RecipeComparison with all differences and interpretations
+        """
+        umf_a = calculate_umf(recipe_a, cone=cone)
+        umf_b = calculate_umf(recipe_b, cone=cone)
+
+        if not umf_a.success:
+            return RecipeComparison(success=False, error=f'{name_a}: {umf_a.error}')
+        if not umf_b.success:
+            return RecipeComparison(success=False, error=f'{name_b}: {umf_b.error}')
+
+        differences = []
+
+        # Compare all oxides in UMF
+        all_oxides = set(umf_a.umf_formula.keys()) | set(umf_b.umf_formula.keys())
+        for oxide in sorted(all_oxides):
+            val_a = umf_a.umf_formula.get(oxide, 0)
+            val_b = umf_b.umf_formula.get(oxide, 0)
+            delta = round(val_b - val_a, 3)
+            delta_pct = round((delta / val_a) * 100, 1) if val_a != 0 else None
+
+            interpretation = self._interpret_oxide_change(oxide, val_a, val_b, delta)
+            differences.append(RecipeDifference(
+                category='oxide',
+                metric=oxide,
+                base_value=val_a,
+                top_value=val_b,
+                delta=delta,
+                delta_percent=delta_pct,
+                interpretation=interpretation,
+            ))
+
+        # Compare ratios
+        ratio_keys = set(umf_a.ratios.keys()) | set(umf_b.ratios.keys())
+        for ratio in sorted(ratio_keys):
+            val_a = umf_a.ratios.get(ratio, 0)
+            val_b = umf_b.ratios.get(ratio, 0)
+            delta = round(val_b - val_a, 2)
+
+            interpretation = self._interpret_ratio_change(ratio, val_a, val_b, delta)
+            differences.append(RecipeDifference(
+                category='ratio',
+                metric=ratio,
+                base_value=val_a,
+                top_value=val_b,
+                delta=delta,
+                delta_percent=None,
+                interpretation=interpretation,
+            ))
+
+        # Compare surface predictions
+        if umf_a.surface_prediction != umf_b.surface_prediction:
+            differences.append(RecipeDifference(
+                category='surface',
+                metric='surface_prediction',
+                base_value=None,
+                top_value=None,
+                delta=None,
+                delta_percent=None,
+                interpretation=f'{name_a} is {umf_a.surface_prediction}, {name_b} is {umf_b.surface_prediction}',
+            ))
+
+        # Compare CTE
+        if umf_a.thermal_expansion is not None and umf_b.thermal_expansion is not None:
+            cte_delta = round(umf_b.thermal_expansion - umf_a.thermal_expansion, 2)
+            if abs(cte_delta) >= 0.1:
+                if cte_delta > 0:
+                    interp = f'{name_b} has higher CTE (+{cte_delta}). Higher crazing risk, lower shivering risk.'
+                else:
+                    interp = f'{name_b} has lower CTE ({cte_delta}). Higher shivering risk, lower crazing risk.'
+                differences.append(RecipeDifference(
+                    category='cte',
+                    metric='thermal_expansion',
+                    base_value=umf_a.thermal_expansion,
+                    top_value=umf_b.thermal_expansion,
+                    delta=cte_delta,
+                    delta_percent=round((cte_delta / umf_a.thermal_expansion) * 100, 1) if umf_a.thermal_expansion else None,
+                    interpretation=interp,
+                ))
+
+        return RecipeComparison(
+            success=True,
+            base_name=name_a,
+            top_name=name_b,
+            differences=differences,
+            base_umf=umf_a.to_dict(),
+            top_umf=umf_b.to_dict(),
+        )
+
+    def _interpret_oxide_change(self, oxide: str, val_a: float, val_b: float, delta: float) -> str:
+        """Generate human interpretation of an oxide change."""
+        if abs(delta) < 0.01:
+            return f'{oxide} is essentially unchanged'
+
+        direction = 'increased' if delta > 0 else 'decreased'
+        magnitude = abs(delta)
+
+        interpretations = {
+            'SiO2': {
+                'increased': f'More silica makes glaze more durable, harder, and glossier. May need higher temperature to melt.',
+                'decreased': f'Less silica makes glaze softer, more fluid, and potentially more matte.',
+            },
+            'Al2O3': {
+                'increased': f'More alumina makes glaze stiffer, more matte, and more durable. Raises melting point.',
+                'decreased': f'Less alumina makes glaze more fluid and glossier. May run more.',
+            },
+            'CaO': {
+                'increased': f'More calcium promotes satin/matte surfaces and increases hardness.',
+                'decreased': f'Less calcium reduces hardness and moves glaze toward glossier surfaces.',
+            },
+            'MgO': {
+                'increased': f'More magnesium promotes dry matte surfaces and can cause crawling.',
+                'decreased': f'Less magnesium reduces matte tendency and crawling risk.',
+            },
+            'K2O': {
+                'increased': f'More potassium increases flux and gloss but raises thermal expansion (crazing risk).',
+                'decreased': f'Less potassium reduces flux and gloss, lowers thermal expansion.',
+            },
+            'Na2O': {
+                'increased': f'More sodium increases flux and gloss but raises thermal expansion (crazing risk).',
+                'decreased': f'Less sodium reduces flux and gloss, lowers thermal expansion.',
+            },
+            'Fe2O3': {
+                'increased': f'More iron darkens color, promotes tenmoku/iron effects.',
+                'decreased': f'Less iron lightens color, reduces iron-based effects.',
+            },
+            'B2O3': {
+                'increased': f'More boron lowers melting point significantly. Running risk at high levels.',
+                'decreased': f'Less boron raises melting point. May need higher cone.',
+            },
+            'ZnO': {
+                'increased': f'More zinc promotes crystal formation and can cause crawling.',
+                'decreased': f'Less zinc reduces crystal tendency and crawling risk.',
+            },
+            'TiO2': {
+                'increased': f'More titanium increases opacity and can promote crystal growth.',
+                'decreased': f'Less titanium reduces opacity and crystal tendency.',
+            },
+        }
+
+        interp = interpretations.get(oxide, {}).get(direction)
+        if interp:
+            return interp
+
+        return f'{oxide} {direction} by {magnitude:.3f}'
+
+    def _interpret_ratio_change(self, ratio: str, val_a: float, val_b: float, delta: float) -> str:
+        """Generate human interpretation of a ratio change."""
+        if abs(delta) < 0.1:
+            return f'{ratio} is essentially unchanged'
+
+        direction = 'increased' if delta > 0 else 'decreased'
+
+        interpretations = {
+            'sio2_al2o3': {
+                'increased': f'Higher SiO₂:Al₂O₃ pushes glaze toward glossy. More durable, harder surface.',
+                'decreased': f'Lower SiO₂:Al₂O₃ pushes glaze toward matte. Softer, potentially more fluid.',
+            },
+            'flux_alumina': {
+                'increased': f'More flux relative to alumina = more fluid, glossier glaze.',
+                'decreased': f'Less flux relative to alumina = stiffer, more matte glaze.',
+            },
+        }
+
+        interp = interpretations.get(ratio, {}).get(direction)
+        if interp:
+            return interp
+
+        return f'{ratio} {direction} by {abs(delta):.2f}'
+
+
+def compare_recipes(recipe_a: str, recipe_b: str,
+                    name_a: str = 'Recipe A', name_b: str = 'Recipe B',
+                    cone: Optional[int] = None) -> RecipeComparison:
+    """Convenience function to compare two recipes."""
+    comparator = RecipeComparator()
+    return comparator.compare(recipe_a, recipe_b, name_a, name_b, cone)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/server.py
+++ b/server.py
@@ -526,7 +526,14 @@ def create_app(config: dict = None) -> Flask:
     @app.route('/api/chemistry/batch', methods=['POST'])
     @rate_limit(requests_per_minute=5)
     def batch_chemistry_analysis():
-        """Run batch UMF and compatibility analysis for all glazes and combinations."""
+        """Run batch UMF and compatibility analysis for all glazes and combinations.
+
+        Request body (optional):
+            cone: Target firing cone for all analyses (default: 10)
+        """
+        data = request.json or {}
+        cone = data.get('cone', 10)
+
         try:
             from core.chemistry import BatchAnalyzer
         except ImportError:
@@ -535,7 +542,8 @@ def create_app(config: dict = None) -> Flask:
         try:
             analyzer = BatchAnalyzer(
                 db_path=config.get('database', {}).get('path', 'glaze.db'),
-                user_id=get_current_user_id() if features['auth_enabled'] else None
+                user_id=get_current_user_id() if features['auth_enabled'] else None,
+                cone=int(cone) if cone else 10,
             )
             report = analyzer.generate_report()
             return jsonify(report)
@@ -561,6 +569,40 @@ def create_app(config: dict = None) -> Flask:
             return jsonify(result)
         except Exception as e:
             logger.error(f"Recipe scaling error: {e}")
+            return jsonify({"error": str(e)}), 500
+
+    @app.route('/api/chemistry/compare', methods=['POST'])
+    @rate_limit(requests_per_minute=60)
+    def compare_glaze_recipes():
+        """Compare two glaze recipes chemically.
+
+        Request body:
+            recipe_a: First recipe string
+            recipe_b: Second recipe string
+            name_a: Name for first recipe (optional)
+            name_b: Name for second recipe (optional)
+            cone: Target firing cone (optional, default 10)
+        """
+        data = request.json or {}
+        recipe_a = data.get('recipe_a', '')
+        recipe_b = data.get('recipe_b', '')
+        name_a = data.get('name_a', 'Recipe A')
+        name_b = data.get('name_b', 'Recipe B')
+        cone = data.get('cone', 10)
+
+        if not recipe_a or not recipe_b:
+            return jsonify({"error": "recipe_a and recipe_b are required"}), 400
+
+        try:
+            from core.chemistry import compare_recipes
+            result = compare_recipes(
+                recipe_a, recipe_b,
+                name_a=name_a, name_b=name_b,
+                cone=int(cone) if cone else 10,
+            )
+            return jsonify(result.to_dict())
+        except Exception as e:
+            logger.error(f"Recipe comparison error: {e}")
             return jsonify({"error": str(e)}), 500
 
     @app.route('/api/chemistry/substitutions', methods=['POST'])

--- a/tests/test_chemistry.py
+++ b/tests/test_chemistry.py
@@ -403,6 +403,51 @@ class TestSubstitutions:
         assert any('Carbonate' in s.substitute for s in suggestions)
 
 
+class TestRecipeComparison:
+    """Recipe comparison tests."""
+
+    def test_compare_recipes_finds_differences(self):
+        """Comparison should identify chemical differences between recipes."""
+        from core.chemistry.compare import compare_recipes
+        result = compare_recipes(
+            'Custer Feldspar 45, Silica 25, Whiting 18, EPK 12, Red Iron Oxide 1.5',
+            'Custer Feldspar 50, Silica 20, Whiting 15, EPK 12, Red Iron Oxide 8',
+            'Celadon', 'Tenmoku', cone=10
+        )
+        assert result.success is True
+        assert len(result.differences) > 0
+        # Should find Fe2O3 difference
+        fe_diffs = [d for d in result.differences if d.metric == 'Fe2O3']
+        assert len(fe_diffs) > 0
+        assert fe_diffs[0].delta > 0  # Tenmoku has more iron
+
+    def test_compare_recipes_interpretation_present(self):
+        """Each difference should include a human interpretation."""
+        from core.chemistry.compare import compare_recipes
+        result = compare_recipes(
+            'Custer Feldspar 45, Silica 25, Whiting 18, EPK 12',
+            'Custer Feldspar 45, Silica 25, Whiting 18, EPK 12',
+            'Same A', 'Same B', cone=10
+        )
+        assert result.success is True
+        # Identical recipes should have minimal differences
+        significant = [d for d in result.differences
+                       if d.category == 'oxide' and abs(d.delta or 0) > 0.01]
+        assert len(significant) == 0
+
+    def test_compare_recipes_surface_change(self):
+        """Comparison should detect surface prediction changes."""
+        from core.chemistry.compare import compare_recipes
+        result = compare_recipes(
+            'Custer Feldspar 45, Silica 25, Whiting 18, EPK 12',
+            'Nepheline Syenite 30, Silica 5, Whiting 15, EPK 40, Dolomite 10',
+            'Glossy', 'Matte', cone=10
+        )
+        assert result.success is True
+        surface_diffs = [d for d in result.differences if d.metric == 'surface_prediction']
+        assert len(surface_diffs) > 0
+
+
 class TestDefectPrediction:
     """Glaze defect prediction tests."""
 


### PR DESCRIPTION
## What

- Adds `/api/chemistry/compare` — side-by-side recipe comparison endpoint
- Wires `cone` parameter through `BatchAnalyzer` for batch UMF/compatibility
- Introduces `RecipeComparator` / `compare_recipes()` in `core.chemistry.compare`

## API

```
POST /api/chemistry/compare
{
  "recipe_a": "Custer Feldspar 45, Silica 25...",
  "recipe_b": "Custer Feldspar 50, Silica 20...",
  "name_a": "Celadon",
  "name_b": "Tenmoku",
  "cone": 10
}
```

Returns UMF deltas, surface shift prediction, and reformulation tips.

## Tests

- 3 new comparison tests added (92 total)
- All passing locally