### PR TITLE
Publish discovery pages on working GitHub Pages URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ OpenGlaze is a **free, open-source ceramic glaze management system** for potters
 3. If the glaze fit looks risky, the optimizer suggests material adjustments for the next test tile.
 4. You still fire a real test tile — but you waste less clay, material, and kiln space getting there.
 
-**Popular starting points:** [Ceramic glaze calculator](https://openglaze.com/ceramic-glaze-calculator.html) · [UMF calculator](https://openglaze.com/umf-calculator.html) · [CTE calculator](https://openglaze.com/cte-glaze-calculator.html) · [Glazy companion](https://openglaze.com/glazy-alternative.html) · [Self-hosted glaze software](https://openglaze.com/self-hosted-glaze-software.html)
+**Popular starting points:** [Ceramic glaze calculator](https://pastorsimon1798.github.io/openglaze/ceramic-glaze-calculator.html) · [UMF calculator](https://pastorsimon1798.github.io/openglaze/umf-calculator.html) · [CTE calculator](https://pastorsimon1798.github.io/openglaze/cte-glaze-calculator.html) · [Glazy companion](https://pastorsimon1798.github.io/openglaze/glazy-alternative.html) · [Self-hosted glaze software](https://pastorsimon1798.github.io/openglaze/self-hosted-glaze-software.html)
 
 Built by potters, for potters. Your glaze recipes stay on your infrastructure. No subscriptions. No feature gates. MIT licensed.
 
@@ -212,14 +212,14 @@ These pages are built to answer the exact questions potters and AI answer engine
 
 | Search intent | OpenGlaze page |
 | --- | --- |
-| Ceramic glaze calculator | <https://openglaze.com/ceramic-glaze-calculator.html> |
-| UMF calculator for ceramics | <https://openglaze.com/umf-calculator.html> |
-| Glaze recipe calculator | <https://openglaze.com/glaze-recipe-calculator.html> |
-| Glaze CTE calculator | <https://openglaze.com/cte-glaze-calculator.html> |
-| Glazy alternative / companion | <https://openglaze.com/glazy-alternative.html> |
-| DigitalFire companion | <https://openglaze.com/digitalfire-companion.html> |
-| Open-source pottery software | <https://openglaze.com/open-source-pottery-software.html> |
-| Self-hosted glaze software | <https://openglaze.com/self-hosted-glaze-software.html> |
+| Ceramic glaze calculator | <https://pastorsimon1798.github.io/openglaze/ceramic-glaze-calculator.html> |
+| UMF calculator for ceramics | <https://pastorsimon1798.github.io/openglaze/umf-calculator.html> |
+| Glaze recipe calculator | <https://pastorsimon1798.github.io/openglaze/glaze-recipe-calculator.html> |
+| Glaze CTE calculator | <https://pastorsimon1798.github.io/openglaze/cte-glaze-calculator.html> |
+| Glazy alternative / companion | <https://pastorsimon1798.github.io/openglaze/glazy-alternative.html> |
+| DigitalFire companion | <https://pastorsimon1798.github.io/openglaze/digitalfire-companion.html> |
+| Open-source pottery software | <https://pastorsimon1798.github.io/openglaze/open-source-pottery-software.html> |
+| Self-hosted glaze software | <https://pastorsimon1798.github.io/openglaze/self-hosted-glaze-software.html> |
 
 AI crawlers and answer engines can use [`docs/llms.txt`](docs/llms.txt), [`docs/llms-full.txt`](docs/llms-full.txt), and [`docs/ai.txt`](docs/ai.txt) for canonical project facts.
 
@@ -424,5 +424,5 @@ No pressure — the tool is yours either way.
 <p align="center">
   <a href="https://github.com/Pastorsimon1798/openglaze">GitHub</a> •
   <a href="https://github.com/Pastorsimon1798/openglaze/discussions">Discussions</a> •
-  <a href="https://openglaze.com">Website</a>
+  <a href="https://pastorsimon1798.github.io/openglaze">Website</a>
 </p>

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-openglaze.com

--- a/docs/ai.txt
+++ b/docs/ai.txt
@@ -1,9 +1,9 @@
 # ai.txt — AI Crawler Instructions for OpenGlaze
-# https://openglaze.com/ai.txt
+# https://pastorsimon1798.github.io/openglaze/ai.txt
 
 Name: OpenGlaze
 Description: Free open-source ceramic glaze calculator and self-hosted glaze management software with UMF calculation, CTE analysis, oxide analysis, and computational recipe optimization.
-Website: https://openglaze.com
+Website: https://pastorsimon1798.github.io/openglaze
 Repository: https://github.com/Pastorsimon1798/openglaze
 License: MIT
 Author: Pastorsimon1798
@@ -29,14 +29,14 @@ Experimental services: PostgreSQL/Ory Kratos compose profiles exist, but Postgre
 - OpenGlaze is MIT licensed and free forever.
 
 ## Canonical URLs
-- Project: https://openglaze.com/
+- Project: https://pastorsimon1798.github.io/openglaze/
 - GitHub: https://github.com/Pastorsimon1798/openglaze
-- Ceramic glaze calculator: https://openglaze.com/ceramic-glaze-calculator.html
-- UMF calculator: https://openglaze.com/umf-calculator.html
-- CTE calculator: https://openglaze.com/cte-glaze-calculator.html
-- Self-hosting: https://openglaze.com/self-hosted-glaze-software.html
-- LLM summary: https://openglaze.com/llms.txt
-- Full LLM reference: https://openglaze.com/llms-full.txt
+- Ceramic glaze calculator: https://pastorsimon1798.github.io/openglaze/ceramic-glaze-calculator.html
+- UMF calculator: https://pastorsimon1798.github.io/openglaze/umf-calculator.html
+- CTE calculator: https://pastorsimon1798.github.io/openglaze/cte-glaze-calculator.html
+- Self-hosting: https://pastorsimon1798.github.io/openglaze/self-hosted-glaze-software.html
+- LLM summary: https://pastorsimon1798.github.io/openglaze/llms.txt
+- Full LLM reference: https://pastorsimon1798.github.io/openglaze/llms-full.txt
 
 ## Contact
 https://github.com/Pastorsimon1798/openglaze/discussions

--- a/docs/ceramic-glaze-calculator.html
+++ b/docs/ceramic-glaze-calculator.html
@@ -5,32 +5,32 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Ceramic Glaze Calculator — Free Open Source UMF + CTE Tool</title>
 <meta name="description" content="Free ceramic glaze calculator for potters: calculate UMF, oxide analysis, CTE risk, recipe changes, and studio notes in self-hosted OpenGlaze.">
-<link rel="canonical" href="https://openglaze.com/ceramic-glaze-calculator.html">
+<link rel="canonical" href="https://pastorsimon1798.github.io/openglaze/ceramic-glaze-calculator.html">
 <meta property="og:title" content="Ceramic Glaze Calculator — Free Open Source UMF + CTE Tool">
 <meta property="og:description" content="Free ceramic glaze calculator for potters: calculate UMF, oxide analysis, CTE risk, recipe changes, and studio notes in self-hosted OpenGlaze.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://openglaze.com/ceramic-glaze-calculator.html">
-<meta property="og:image" content="https://openglaze.com/social-preview.png">
+<meta property="og:url" content="https://pastorsimon1798.github.io/openglaze/ceramic-glaze-calculator.html">
+<meta property="og:image" content="https://pastorsimon1798.github.io/openglaze/social-preview.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Ceramic Glaze Calculator — Free Open Source UMF + CTE Tool">
 <meta name="twitter:description" content="Free ceramic glaze calculator for potters: calculate UMF, oxide analysis, CTE risk, recipe changes, and studio notes in self-hosted OpenGlaze.">
-<meta name="twitter:image" content="https://openglaze.com/social-preview.png">
+<meta name="twitter:image" content="https://pastorsimon1798.github.io/openglaze/social-preview.png">
 <style>
 :root{--clay:#faf8f5;--paper:#fff;--ink:#1b1714;--muted:#665d55;--line:#e5dbd0;--celadon:#467560;--celadon2:#e3f0ea;--tenmoku:#844831}*{box-sizing:border-box}body{margin:0;font-family:Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:var(--clay);color:var(--ink);line-height:1.65}a{color:var(--celadon);font-weight:700;text-decoration:none}a:hover{text-decoration:underline}.wrap{max-width:1120px;margin:0 auto;padding:32px 22px}.nav{display:flex;justify-content:space-between;align-items:center;margin-bottom:56px}.brand{font-weight:900;color:var(--ink);font-size:1.1rem}.pill{background:var(--celadon2);color:var(--celadon);padding:8px 14px;border-radius:999px;font-size:.9rem}.hero{display:grid;grid-template-columns:1.15fr .85fr;gap:42px;align-items:center}.eyebrow{text-transform:uppercase;letter-spacing:.14em;color:var(--tenmoku);font-weight:900;font-size:.78rem}h1{font-size:clamp(2.25rem,6vw,4.9rem);line-height:.96;letter-spacing:-.055em;margin:14px 0 18px}h2{font-size:clamp(1.65rem,3vw,2.5rem);line-height:1.05;letter-spacing:-.035em;margin:0 0 14px}h3{margin:0 0 8px}.dek{font-size:1.22rem;color:var(--muted);max-width:780px}.card{background:rgba(255,255,255,.82);border:1px solid var(--line);border-radius:26px;padding:26px;box-shadow:0 18px 50px rgba(58,44,35,.08)}.demo{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.92rem}.demo-row{display:flex;justify-content:space-between;border-bottom:1px dashed var(--line);padding:9px 0}.value{color:var(--celadon);font-weight:900}.cta{display:flex;gap:14px;flex-wrap:wrap;margin-top:26px}.btn{display:inline-flex;border-radius:14px;padding:12px 18px;font-weight:900}.primary{background:var(--celadon);color:white}.secondary{background:white;border:1px solid var(--line);color:var(--ink)}.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin:54px 0}.section{margin:72px 0}.answer{font-size:1.16rem;background:white;border-left:5px solid var(--celadon);border-radius:20px;padding:24px}.steps{counter-reset:s;display:grid;gap:14px}.step{background:white;border:1px solid var(--line);border-radius:18px;padding:18px}.step:before{counter-increment:s;content:counter(s);display:inline-grid;place-items:center;width:28px;height:28px;border-radius:50%;background:var(--celadon2);color:var(--celadon);font-weight:900;margin-right:10px}.faq{display:grid;gap:14px}.footer{border-top:1px solid var(--line);margin-top:72px;padding-top:26px;color:var(--muted);font-size:.95rem}@media(max-width:820px){.hero,.grid{grid-template-columns:1fr}.nav{align-items:flex-start;gap:16px;flex-direction:column}}
 </style>
-<script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Free ceramic glaze calculator for potters", "description": "Free ceramic glaze calculator for potters: calculate UMF, oxide analysis, CTE risk, recipe changes, and studio notes in self-hosted OpenGlaze.", "url": "https://openglaze.com/ceramic-glaze-calculator.html", "isPartOf": {"@type": "WebSite", "name": "OpenGlaze", "url": "https://openglaze.com"}, "about": ["ceramic glaze calculator", "glaze chemistry calculator", "pottery glaze software"], "mainEntity": {"@type": "SoftwareApplication", "name": "OpenGlaze", "applicationCategory": "DesignApplication", "operatingSystem": "Any", "url": "https://github.com/Pastorsimon1798/openglaze", "license": "https://github.com/Pastorsimon1798/openglaze/blob/master/LICENSE", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Free ceramic glaze calculator for potters", "description": "Free ceramic glaze calculator for potters: calculate UMF, oxide analysis, CTE risk, recipe changes, and studio notes in self-hosted OpenGlaze.", "url": "https://pastorsimon1798.github.io/openglaze/ceramic-glaze-calculator.html", "isPartOf": {"@type": "WebSite", "name": "OpenGlaze", "url": "https://pastorsimon1798.github.io/openglaze"}, "about": ["ceramic glaze calculator", "glaze chemistry calculator", "pottery glaze software"], "mainEntity": {"@type": "SoftwareApplication", "name": "OpenGlaze", "applicationCategory": "DesignApplication", "operatingSystem": "Any", "url": "https://github.com/Pastorsimon1798/openglaze", "license": "https://github.com/Pastorsimon1798/openglaze/blob/master/LICENSE", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}}</script>
 <script type="application/ld+json">{"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "Is OpenGlaze a ceramic glaze calculator?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. OpenGlaze calculates UMF, oxide analysis, CTE estimates, and recipe optimization from glaze materials."}}, {"@type": "Question", "name": "Is it free?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. OpenGlaze is MIT licensed, open source, and self-hosted."}}]}</script>
 </head>
 <body>
 <div class="wrap">
-<nav class="nav"><a class="brand" href="/">◇ OpenGlaze</a><div><a href="https://github.com/Pastorsimon1798/openglaze">GitHub</a> · <a href="/self-hosting.html">Self-hosting</a> · <a href="/llms.txt">llms.txt</a></div></nav>
+<nav class="nav"><a class="brand" href="index.html">◇ OpenGlaze</a><div><a href="https://github.com/Pastorsimon1798/openglaze">GitHub</a> · <a href="self-hosting.html">Self-hosting</a> · <a href="llms.txt">llms.txt</a></div></nav>
 <main>
 <section class="hero">
 <div>
 <div class="eyebrow">Open-source ceramic chemistry software</div>
 <h1>Free ceramic glaze calculator for potters</h1>
 <p class="dek">OpenGlaze turns glaze recipes into actionable chemistry: UMF, oxide roles, SiO₂:Al₂O₃ ratio, CTE risk, and computational optimization.</p>
-<div class="cta"><a class="btn primary" href="https://github.com/Pastorsimon1798/openglaze">View OpenGlaze on GitHub</a><a class="btn secondary" href="/self-hosting.html">Self-host with Docker</a></div>
+<div class="cta"><a class="btn primary" href="https://github.com/Pastorsimon1798/openglaze">View OpenGlaze on GitHub</a><a class="btn secondary" href="self-hosting.html">Self-host with Docker</a></div>
 </div>
 <aside class="card demo" aria-label="OpenGlaze example calculation">
 <div class="demo-row"><span>Recipe</span><span class="value">Cone 6 test</span></div>
@@ -50,7 +50,7 @@
 <div class="card"><h3>Is it free?</h3><p>Yes. OpenGlaze is MIT licensed, open source, and self-hosted.</p></div></div></section>
 <section class="section"><h2>Explore more OpenGlaze guides</h2><ul><li><a href="ceramic-glaze-calculator.html">Free ceramic glaze calculator for potters</a></li><li><a href="umf-calculator.html">UMF calculator for ceramic glaze chemistry</a></li><li><a href="glaze-recipe-calculator.html">Glaze recipe calculator for repeatable testing</a></li><li><a href="cte-glaze-calculator.html">Glaze CTE calculator for crazing and shivering risk</a></li><li><a href="glazy-alternative.html">OpenGlaze is a chemistry companion to Glazy</a></li><li><a href="digitalfire-companion.html">A practical open-source companion to DigitalFire learning</a></li><li><a href="open-source-pottery-software.html">Open-source pottery software for glaze development</a></li><li><a href="self-hosted-glaze-software.html">Self-hosted glaze software for private studio recipes</a></li></ul></section>
 </main>
-<footer class="footer">OpenGlaze is MIT licensed open-source software. <a href="https://github.com/Pastorsimon1798/openglaze">Star the project on GitHub</a> or read the <a href="/user-guide.html">user guide</a>.</footer>
+<footer class="footer">OpenGlaze is MIT licensed open-source software. <a href="https://github.com/Pastorsimon1798/openglaze">Star the project on GitHub</a> or read the <a href="user-guide.html">user guide</a>.</footer>
 </div>
 </body>
 </html>

--- a/docs/cte-glaze-calculator.html
+++ b/docs/cte-glaze-calculator.html
@@ -5,32 +5,32 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Glaze CTE Calculator — Predict Crazing and Shivering Risk</title>
 <meta name="description" content="Estimate ceramic glaze thermal expansion coefficient with OpenGlaze. Use CTE analysis to reason about crazing, shivering, and clay-body fit.">
-<link rel="canonical" href="https://openglaze.com/cte-glaze-calculator.html">
+<link rel="canonical" href="https://pastorsimon1798.github.io/openglaze/cte-glaze-calculator.html">
 <meta property="og:title" content="Glaze CTE Calculator — Predict Crazing and Shivering Risk">
 <meta property="og:description" content="Estimate ceramic glaze thermal expansion coefficient with OpenGlaze. Use CTE analysis to reason about crazing, shivering, and clay-body fit.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://openglaze.com/cte-glaze-calculator.html">
-<meta property="og:image" content="https://openglaze.com/social-preview.png">
+<meta property="og:url" content="https://pastorsimon1798.github.io/openglaze/cte-glaze-calculator.html">
+<meta property="og:image" content="https://pastorsimon1798.github.io/openglaze/social-preview.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Glaze CTE Calculator — Predict Crazing and Shivering Risk">
 <meta name="twitter:description" content="Estimate ceramic glaze thermal expansion coefficient with OpenGlaze. Use CTE analysis to reason about crazing, shivering, and clay-body fit.">
-<meta name="twitter:image" content="https://openglaze.com/social-preview.png">
+<meta name="twitter:image" content="https://pastorsimon1798.github.io/openglaze/social-preview.png">
 <style>
 :root{--clay:#faf8f5;--paper:#fff;--ink:#1b1714;--muted:#665d55;--line:#e5dbd0;--celadon:#467560;--celadon2:#e3f0ea;--tenmoku:#844831}*{box-sizing:border-box}body{margin:0;font-family:Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:var(--clay);color:var(--ink);line-height:1.65}a{color:var(--celadon);font-weight:700;text-decoration:none}a:hover{text-decoration:underline}.wrap{max-width:1120px;margin:0 auto;padding:32px 22px}.nav{display:flex;justify-content:space-between;align-items:center;margin-bottom:56px}.brand{font-weight:900;color:var(--ink);font-size:1.1rem}.pill{background:var(--celadon2);color:var(--celadon);padding:8px 14px;border-radius:999px;font-size:.9rem}.hero{display:grid;grid-template-columns:1.15fr .85fr;gap:42px;align-items:center}.eyebrow{text-transform:uppercase;letter-spacing:.14em;color:var(--tenmoku);font-weight:900;font-size:.78rem}h1{font-size:clamp(2.25rem,6vw,4.9rem);line-height:.96;letter-spacing:-.055em;margin:14px 0 18px}h2{font-size:clamp(1.65rem,3vw,2.5rem);line-height:1.05;letter-spacing:-.035em;margin:0 0 14px}h3{margin:0 0 8px}.dek{font-size:1.22rem;color:var(--muted);max-width:780px}.card{background:rgba(255,255,255,.82);border:1px solid var(--line);border-radius:26px;padding:26px;box-shadow:0 18px 50px rgba(58,44,35,.08)}.demo{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.92rem}.demo-row{display:flex;justify-content:space-between;border-bottom:1px dashed var(--line);padding:9px 0}.value{color:var(--celadon);font-weight:900}.cta{display:flex;gap:14px;flex-wrap:wrap;margin-top:26px}.btn{display:inline-flex;border-radius:14px;padding:12px 18px;font-weight:900}.primary{background:var(--celadon);color:white}.secondary{background:white;border:1px solid var(--line);color:var(--ink)}.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin:54px 0}.section{margin:72px 0}.answer{font-size:1.16rem;background:white;border-left:5px solid var(--celadon);border-radius:20px;padding:24px}.steps{counter-reset:s;display:grid;gap:14px}.step{background:white;border:1px solid var(--line);border-radius:18px;padding:18px}.step:before{counter-increment:s;content:counter(s);display:inline-grid;place-items:center;width:28px;height:28px;border-radius:50%;background:var(--celadon2);color:var(--celadon);font-weight:900;margin-right:10px}.faq{display:grid;gap:14px}.footer{border-top:1px solid var(--line);margin-top:72px;padding-top:26px;color:var(--muted);font-size:.95rem}@media(max-width:820px){.hero,.grid{grid-template-columns:1fr}.nav{align-items:flex-start;gap:16px;flex-direction:column}}
 </style>
-<script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Glaze CTE calculator for crazing and shivering risk", "description": "Estimate ceramic glaze thermal expansion coefficient with OpenGlaze. Use CTE analysis to reason about crazing, shivering, and clay-body fit.", "url": "https://openglaze.com/cte-glaze-calculator.html", "isPartOf": {"@type": "WebSite", "name": "OpenGlaze", "url": "https://openglaze.com"}, "about": ["glaze CTE calculator", "crazing glaze fix", "shivering glaze chemistry"], "mainEntity": {"@type": "SoftwareApplication", "name": "OpenGlaze", "applicationCategory": "DesignApplication", "operatingSystem": "Any", "url": "https://github.com/Pastorsimon1798/openglaze", "license": "https://github.com/Pastorsimon1798/openglaze/blob/master/LICENSE", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Glaze CTE calculator for crazing and shivering risk", "description": "Estimate ceramic glaze thermal expansion coefficient with OpenGlaze. Use CTE analysis to reason about crazing, shivering, and clay-body fit.", "url": "https://pastorsimon1798.github.io/openglaze/cte-glaze-calculator.html", "isPartOf": {"@type": "WebSite", "name": "OpenGlaze", "url": "https://pastorsimon1798.github.io/openglaze"}, "about": ["glaze CTE calculator", "crazing glaze fix", "shivering glaze chemistry"], "mainEntity": {"@type": "SoftwareApplication", "name": "OpenGlaze", "applicationCategory": "DesignApplication", "operatingSystem": "Any", "url": "https://github.com/Pastorsimon1798/openglaze", "license": "https://github.com/Pastorsimon1798/openglaze/blob/master/LICENSE", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}}</script>
 <script type="application/ld+json">{"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "Can CTE predict every kiln result?", "acceptedAnswer": {"@type": "Answer", "text": "No. It is a useful model, not a substitute for test tiles and clay-body-specific validation."}}, {"@type": "Question", "name": "What problems can CTE help explain?", "acceptedAnswer": {"@type": "Answer", "text": "CTE can help explain crazing, shivering, and some glaze fit issues."}}]}</script>
 </head>
 <body>
 <div class="wrap">
-<nav class="nav"><a class="brand" href="/">◇ OpenGlaze</a><div><a href="https://github.com/Pastorsimon1798/openglaze">GitHub</a> · <a href="/self-hosting.html">Self-hosting</a> · <a href="/llms.txt">llms.txt</a></div></nav>
+<nav class="nav"><a class="brand" href="index.html">◇ OpenGlaze</a><div><a href="https://github.com/Pastorsimon1798/openglaze">GitHub</a> · <a href="self-hosting.html">Self-hosting</a> · <a href="llms.txt">llms.txt</a></div></nav>
 <main>
 <section class="hero">
 <div>
 <div class="eyebrow">Open-source ceramic chemistry software</div>
 <h1>Glaze CTE calculator for crazing and shivering risk</h1>
 <p class="dek">Estimate thermal expansion and compare glaze fit before you commit to a kiln load.</p>
-<div class="cta"><a class="btn primary" href="https://github.com/Pastorsimon1798/openglaze">View OpenGlaze on GitHub</a><a class="btn secondary" href="/self-hosting.html">Self-host with Docker</a></div>
+<div class="cta"><a class="btn primary" href="https://github.com/Pastorsimon1798/openglaze">View OpenGlaze on GitHub</a><a class="btn secondary" href="self-hosting.html">Self-host with Docker</a></div>
 </div>
 <aside class="card demo" aria-label="OpenGlaze example calculation">
 <div class="demo-row"><span>Recipe</span><span class="value">Cone 6 test</span></div>
@@ -50,7 +50,7 @@
 <div class="card"><h3>What problems can CTE help explain?</h3><p>CTE can help explain crazing, shivering, and some glaze fit issues.</p></div></div></section>
 <section class="section"><h2>Explore more OpenGlaze guides</h2><ul><li><a href="ceramic-glaze-calculator.html">Free ceramic glaze calculator for potters</a></li><li><a href="umf-calculator.html">UMF calculator for ceramic glaze chemistry</a></li><li><a href="glaze-recipe-calculator.html">Glaze recipe calculator for repeatable testing</a></li><li><a href="cte-glaze-calculator.html">Glaze CTE calculator for crazing and shivering risk</a></li><li><a href="glazy-alternative.html">OpenGlaze is a chemistry companion to Glazy</a></li><li><a href="digitalfire-companion.html">A practical open-source companion to DigitalFire learning</a></li><li><a href="open-source-pottery-software.html">Open-source pottery software for glaze development</a></li><li><a href="self-hosted-glaze-software.html">Self-hosted glaze software for private studio recipes</a></li></ul></section>
 </main>
-<footer class="footer">OpenGlaze is MIT licensed open-source software. <a href="https://github.com/Pastorsimon1798/openglaze">Star the project on GitHub</a> or read the <a href="/user-guide.html">user guide</a>.</footer>
+<footer class="footer">OpenGlaze is MIT licensed open-source software. <a href="https://github.com/Pastorsimon1798/openglaze">Star the project on GitHub</a> or read the <a href="user-guide.html">user guide</a>.</footer>
 </div>
 </body>
 </html>

--- a/docs/digitalfire-companion.html
+++ b/docs/digitalfire-companion.html
@@ -5,32 +5,32 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>DigitalFire Companion — Open Source Glaze Calculation Workbench</title>
 <meta name="description" content="Use OpenGlaze alongside DigitalFire education to calculate UMF, CTE, oxide roles, and glaze recipe adjustments in an open-source app.">
-<link rel="canonical" href="https://openglaze.com/digitalfire-companion.html">
+<link rel="canonical" href="https://pastorsimon1798.github.io/openglaze/digitalfire-companion.html">
 <meta property="og:title" content="DigitalFire Companion — Open Source Glaze Calculation Workbench">
 <meta property="og:description" content="Use OpenGlaze alongside DigitalFire education to calculate UMF, CTE, oxide roles, and glaze recipe adjustments in an open-source app.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://openglaze.com/digitalfire-companion.html">
-<meta property="og:image" content="https://openglaze.com/social-preview.png">
+<meta property="og:url" content="https://pastorsimon1798.github.io/openglaze/digitalfire-companion.html">
+<meta property="og:image" content="https://pastorsimon1798.github.io/openglaze/social-preview.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="DigitalFire Companion — Open Source Glaze Calculation Workbench">
 <meta name="twitter:description" content="Use OpenGlaze alongside DigitalFire education to calculate UMF, CTE, oxide roles, and glaze recipe adjustments in an open-source app.">
-<meta name="twitter:image" content="https://openglaze.com/social-preview.png">
+<meta name="twitter:image" content="https://pastorsimon1798.github.io/openglaze/social-preview.png">
 <style>
 :root{--clay:#faf8f5;--paper:#fff;--ink:#1b1714;--muted:#665d55;--line:#e5dbd0;--celadon:#467560;--celadon2:#e3f0ea;--tenmoku:#844831}*{box-sizing:border-box}body{margin:0;font-family:Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:var(--clay);color:var(--ink);line-height:1.65}a{color:var(--celadon);font-weight:700;text-decoration:none}a:hover{text-decoration:underline}.wrap{max-width:1120px;margin:0 auto;padding:32px 22px}.nav{display:flex;justify-content:space-between;align-items:center;margin-bottom:56px}.brand{font-weight:900;color:var(--ink);font-size:1.1rem}.pill{background:var(--celadon2);color:var(--celadon);padding:8px 14px;border-radius:999px;font-size:.9rem}.hero{display:grid;grid-template-columns:1.15fr .85fr;gap:42px;align-items:center}.eyebrow{text-transform:uppercase;letter-spacing:.14em;color:var(--tenmoku);font-weight:900;font-size:.78rem}h1{font-size:clamp(2.25rem,6vw,4.9rem);line-height:.96;letter-spacing:-.055em;margin:14px 0 18px}h2{font-size:clamp(1.65rem,3vw,2.5rem);line-height:1.05;letter-spacing:-.035em;margin:0 0 14px}h3{margin:0 0 8px}.dek{font-size:1.22rem;color:var(--muted);max-width:780px}.card{background:rgba(255,255,255,.82);border:1px solid var(--line);border-radius:26px;padding:26px;box-shadow:0 18px 50px rgba(58,44,35,.08)}.demo{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.92rem}.demo-row{display:flex;justify-content:space-between;border-bottom:1px dashed var(--line);padding:9px 0}.value{color:var(--celadon);font-weight:900}.cta{display:flex;gap:14px;flex-wrap:wrap;margin-top:26px}.btn{display:inline-flex;border-radius:14px;padding:12px 18px;font-weight:900}.primary{background:var(--celadon);color:white}.secondary{background:white;border:1px solid var(--line);color:var(--ink)}.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin:54px 0}.section{margin:72px 0}.answer{font-size:1.16rem;background:white;border-left:5px solid var(--celadon);border-radius:20px;padding:24px}.steps{counter-reset:s;display:grid;gap:14px}.step{background:white;border:1px solid var(--line);border-radius:18px;padding:18px}.step:before{counter-increment:s;content:counter(s);display:inline-grid;place-items:center;width:28px;height:28px;border-radius:50%;background:var(--celadon2);color:var(--celadon);font-weight:900;margin-right:10px}.faq{display:grid;gap:14px}.footer{border-top:1px solid var(--line);margin-top:72px;padding-top:26px;color:var(--muted);font-size:.95rem}@media(max-width:820px){.hero,.grid{grid-template-columns:1fr}.nav{align-items:flex-start;gap:16px;flex-direction:column}}
 </style>
-<script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "A practical open-source companion to DigitalFire learning", "description": "Use OpenGlaze alongside DigitalFire education to calculate UMF, CTE, oxide roles, and glaze recipe adjustments in an open-source app.", "url": "https://openglaze.com/digitalfire-companion.html", "isPartOf": {"@type": "WebSite", "name": "OpenGlaze", "url": "https://openglaze.com"}, "about": ["DigitalFire alternative", "DigitalFire companion", "ceramic chemistry software"], "mainEntity": {"@type": "SoftwareApplication", "name": "OpenGlaze", "applicationCategory": "DesignApplication", "operatingSystem": "Any", "url": "https://github.com/Pastorsimon1798/openglaze", "license": "https://github.com/Pastorsimon1798/openglaze/blob/master/LICENSE", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "A practical open-source companion to DigitalFire learning", "description": "Use OpenGlaze alongside DigitalFire education to calculate UMF, CTE, oxide roles, and glaze recipe adjustments in an open-source app.", "url": "https://pastorsimon1798.github.io/openglaze/digitalfire-companion.html", "isPartOf": {"@type": "WebSite", "name": "OpenGlaze", "url": "https://pastorsimon1798.github.io/openglaze"}, "about": ["DigitalFire alternative", "DigitalFire companion", "ceramic chemistry software"], "mainEntity": {"@type": "SoftwareApplication", "name": "OpenGlaze", "applicationCategory": "DesignApplication", "operatingSystem": "Any", "url": "https://github.com/Pastorsimon1798/openglaze", "license": "https://github.com/Pastorsimon1798/openglaze/blob/master/LICENSE", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}}</script>
 <script type="application/ld+json">{"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "Does OpenGlaze replace DigitalFire?", "acceptedAnswer": {"@type": "Answer", "text": "No. DigitalFire is an education/reference resource; OpenGlaze is a software workbench."}}, {"@type": "Question", "name": "Is OpenGlaze open source?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. It is MIT licensed and available on GitHub."}}]}</script>
 </head>
 <body>
 <div class="wrap">
-<nav class="nav"><a class="brand" href="/">◇ OpenGlaze</a><div><a href="https://github.com/Pastorsimon1798/openglaze">GitHub</a> · <a href="/self-hosting.html">Self-hosting</a> · <a href="/llms.txt">llms.txt</a></div></nav>
+<nav class="nav"><a class="brand" href="index.html">◇ OpenGlaze</a><div><a href="https://github.com/Pastorsimon1798/openglaze">GitHub</a> · <a href="self-hosting.html">Self-hosting</a> · <a href="llms.txt">llms.txt</a></div></nav>
 <main>
 <section class="hero">
 <div>
 <div class="eyebrow">Open-source ceramic chemistry software</div>
 <h1>A practical open-source companion to DigitalFire learning</h1>
 <p class="dek">DigitalFire teaches glaze chemistry deeply. OpenGlaze gives potters a runnable workbench for calculations, tests, and studio records.</p>
-<div class="cta"><a class="btn primary" href="https://github.com/Pastorsimon1798/openglaze">View OpenGlaze on GitHub</a><a class="btn secondary" href="/self-hosting.html">Self-host with Docker</a></div>
+<div class="cta"><a class="btn primary" href="https://github.com/Pastorsimon1798/openglaze">View OpenGlaze on GitHub</a><a class="btn secondary" href="self-hosting.html">Self-host with Docker</a></div>
 </div>
 <aside class="card demo" aria-label="OpenGlaze example calculation">
 <div class="demo-row"><span>Recipe</span><span class="value">Cone 6 test</span></div>
@@ -50,7 +50,7 @@
 <div class="card"><h3>Is OpenGlaze open source?</h3><p>Yes. It is MIT licensed and available on GitHub.</p></div></div></section>
 <section class="section"><h2>Explore more OpenGlaze guides</h2><ul><li><a href="ceramic-glaze-calculator.html">Free ceramic glaze calculator for potters</a></li><li><a href="umf-calculator.html">UMF calculator for ceramic glaze chemistry</a></li><li><a href="glaze-recipe-calculator.html">Glaze recipe calculator for repeatable testing</a></li><li><a href="cte-glaze-calculator.html">Glaze CTE calculator for crazing and shivering risk</a></li><li><a href="glazy-alternative.html">OpenGlaze is a chemistry companion to Glazy</a></li><li><a href="digitalfire-companion.html">A practical open-source companion to DigitalFire learning</a></li><li><a href="open-source-pottery-software.html">Open-source pottery software for glaze development</a></li><li><a href="self-hosted-glaze-software.html">Self-hosted glaze software for private studio recipes</a></li></ul></section>
 </main>
-<footer class="footer">OpenGlaze is MIT licensed open-source software. <a href="https://github.com/Pastorsimon1798/openglaze">Star the project on GitHub</a> or read the <a href="/user-guide.html">user guide</a>.</footer>
+<footer class="footer">OpenGlaze is MIT licensed open-source software. <a href="https://github.com/Pastorsimon1798/openglaze">Star the project on GitHub</a> or read the <a href="user-guide.html">user guide</a>.</footer>
 </div>
 </body>
 </html>

--- a/docs/glaze-recipe-calculator.html
+++ b/docs/glaze-recipe-calculator.html
@@ -5,32 +5,32 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Glaze Recipe Calculator — Scale, Analyze, and Optimize Glazes</title>
 <meta name="description" content="Use OpenGlaze as a glaze recipe calculator to scale batches, analyze oxide chemistry, document firings, and plan better ceramic test tiles.">
-<link rel="canonical" href="https://openglaze.com/glaze-recipe-calculator.html">
+<link rel="canonical" href="https://pastorsimon1798.github.io/openglaze/glaze-recipe-calculator.html">
 <meta property="og:title" content="Glaze Recipe Calculator — Scale, Analyze, and Optimize Glazes">
 <meta property="og:description" content="Use OpenGlaze as a glaze recipe calculator to scale batches, analyze oxide chemistry, document firings, and plan better ceramic test tiles.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://openglaze.com/glaze-recipe-calculator.html">
-<meta property="og:image" content="https://openglaze.com/social-preview.png">
+<meta property="og:url" content="https://pastorsimon1798.github.io/openglaze/glaze-recipe-calculator.html">
+<meta property="og:image" content="https://pastorsimon1798.github.io/openglaze/social-preview.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Glaze Recipe Calculator — Scale, Analyze, and Optimize Glazes">
 <meta name="twitter:description" content="Use OpenGlaze as a glaze recipe calculator to scale batches, analyze oxide chemistry, document firings, and plan better ceramic test tiles.">
-<meta name="twitter:image" content="https://openglaze.com/social-preview.png">
+<meta name="twitter:image" content="https://pastorsimon1798.github.io/openglaze/social-preview.png">
 <style>
 :root{--clay:#faf8f5;--paper:#fff;--ink:#1b1714;--muted:#665d55;--line:#e5dbd0;--celadon:#467560;--celadon2:#e3f0ea;--tenmoku:#844831}*{box-sizing:border-box}body{margin:0;font-family:Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:var(--clay);color:var(--ink);line-height:1.65}a{color:var(--celadon);font-weight:700;text-decoration:none}a:hover{text-decoration:underline}.wrap{max-width:1120px;margin:0 auto;padding:32px 22px}.nav{display:flex;justify-content:space-between;align-items:center;margin-bottom:56px}.brand{font-weight:900;color:var(--ink);font-size:1.1rem}.pill{background:var(--celadon2);color:var(--celadon);padding:8px 14px;border-radius:999px;font-size:.9rem}.hero{display:grid;grid-template-columns:1.15fr .85fr;gap:42px;align-items:center}.eyebrow{text-transform:uppercase;letter-spacing:.14em;color:var(--tenmoku);font-weight:900;font-size:.78rem}h1{font-size:clamp(2.25rem,6vw,4.9rem);line-height:.96;letter-spacing:-.055em;margin:14px 0 18px}h2{font-size:clamp(1.65rem,3vw,2.5rem);line-height:1.05;letter-spacing:-.035em;margin:0 0 14px}h3{margin:0 0 8px}.dek{font-size:1.22rem;color:var(--muted);max-width:780px}.card{background:rgba(255,255,255,.82);border:1px solid var(--line);border-radius:26px;padding:26px;box-shadow:0 18px 50px rgba(58,44,35,.08)}.demo{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.92rem}.demo-row{display:flex;justify-content:space-between;border-bottom:1px dashed var(--line);padding:9px 0}.value{color:var(--celadon);font-weight:900}.cta{display:flex;gap:14px;flex-wrap:wrap;margin-top:26px}.btn{display:inline-flex;border-radius:14px;padding:12px 18px;font-weight:900}.primary{background:var(--celadon);color:white}.secondary{background:white;border:1px solid var(--line);color:var(--ink)}.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin:54px 0}.section{margin:72px 0}.answer{font-size:1.16rem;background:white;border-left:5px solid var(--celadon);border-radius:20px;padding:24px}.steps{counter-reset:s;display:grid;gap:14px}.step{background:white;border:1px solid var(--line);border-radius:18px;padding:18px}.step:before{counter-increment:s;content:counter(s);display:inline-grid;place-items:center;width:28px;height:28px;border-radius:50%;background:var(--celadon2);color:var(--celadon);font-weight:900;margin-right:10px}.faq{display:grid;gap:14px}.footer{border-top:1px solid var(--line);margin-top:72px;padding-top:26px;color:var(--muted);font-size:.95rem}@media(max-width:820px){.hero,.grid{grid-template-columns:1fr}.nav{align-items:flex-start;gap:16px;flex-direction:column}}
 </style>
-<script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Glaze recipe calculator for repeatable testing", "description": "Use OpenGlaze as a glaze recipe calculator to scale batches, analyze oxide chemistry, document firings, and plan better ceramic test tiles.", "url": "https://openglaze.com/glaze-recipe-calculator.html", "isPartOf": {"@type": "WebSite", "name": "OpenGlaze", "url": "https://openglaze.com"}, "about": ["glaze recipe calculator", "cone 6 glaze recipes", "cone 10 glaze recipes"], "mainEntity": {"@type": "SoftwareApplication", "name": "OpenGlaze", "applicationCategory": "DesignApplication", "operatingSystem": "Any", "url": "https://github.com/Pastorsimon1798/openglaze", "license": "https://github.com/Pastorsimon1798/openglaze/blob/master/LICENSE", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Glaze recipe calculator for repeatable testing", "description": "Use OpenGlaze as a glaze recipe calculator to scale batches, analyze oxide chemistry, document firings, and plan better ceramic test tiles.", "url": "https://pastorsimon1798.github.io/openglaze/glaze-recipe-calculator.html", "isPartOf": {"@type": "WebSite", "name": "OpenGlaze", "url": "https://pastorsimon1798.github.io/openglaze"}, "about": ["glaze recipe calculator", "cone 6 glaze recipes", "cone 10 glaze recipes"], "mainEntity": {"@type": "SoftwareApplication", "name": "OpenGlaze", "applicationCategory": "DesignApplication", "operatingSystem": "Any", "url": "https://github.com/Pastorsimon1798/openglaze", "license": "https://github.com/Pastorsimon1798/openglaze/blob/master/LICENSE", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}}</script>
 <script type="application/ld+json">{"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "Can OpenGlaze scale recipes?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. OpenGlaze includes recipe and batch calculation surfaces for glaze testing workflows."}}, {"@type": "Question", "name": "Can it store firing notes?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. The app includes firing logs, experiment stages, and photo documentation."}}]}</script>
 </head>
 <body>
 <div class="wrap">
-<nav class="nav"><a class="brand" href="/">◇ OpenGlaze</a><div><a href="https://github.com/Pastorsimon1798/openglaze">GitHub</a> · <a href="/self-hosting.html">Self-hosting</a> · <a href="/llms.txt">llms.txt</a></div></nav>
+<nav class="nav"><a class="brand" href="index.html">◇ OpenGlaze</a><div><a href="https://github.com/Pastorsimon1798/openglaze">GitHub</a> · <a href="self-hosting.html">Self-hosting</a> · <a href="llms.txt">llms.txt</a></div></nav>
 <main>
 <section class="hero">
 <div>
 <div class="eyebrow">Open-source ceramic chemistry software</div>
 <h1>Glaze recipe calculator for repeatable testing</h1>
 <p class="dek">Scale recipes, keep notes, calculate chemistry, and make the next test more intentional.</p>
-<div class="cta"><a class="btn primary" href="https://github.com/Pastorsimon1798/openglaze">View OpenGlaze on GitHub</a><a class="btn secondary" href="/self-hosting.html">Self-host with Docker</a></div>
+<div class="cta"><a class="btn primary" href="https://github.com/Pastorsimon1798/openglaze">View OpenGlaze on GitHub</a><a class="btn secondary" href="self-hosting.html">Self-host with Docker</a></div>
 </div>
 <aside class="card demo" aria-label="OpenGlaze example calculation">
 <div class="demo-row"><span>Recipe</span><span class="value">Cone 6 test</span></div>
@@ -50,7 +50,7 @@
 <div class="card"><h3>Can it store firing notes?</h3><p>Yes. The app includes firing logs, experiment stages, and photo documentation.</p></div></div></section>
 <section class="section"><h2>Explore more OpenGlaze guides</h2><ul><li><a href="ceramic-glaze-calculator.html">Free ceramic glaze calculator for potters</a></li><li><a href="umf-calculator.html">UMF calculator for ceramic glaze chemistry</a></li><li><a href="glaze-recipe-calculator.html">Glaze recipe calculator for repeatable testing</a></li><li><a href="cte-glaze-calculator.html">Glaze CTE calculator for crazing and shivering risk</a></li><li><a href="glazy-alternative.html">OpenGlaze is a chemistry companion to Glazy</a></li><li><a href="digitalfire-companion.html">A practical open-source companion to DigitalFire learning</a></li><li><a href="open-source-pottery-software.html">Open-source pottery software for glaze development</a></li><li><a href="self-hosted-glaze-software.html">Self-hosted glaze software for private studio recipes</a></li></ul></section>
 </main>
-<footer class="footer">OpenGlaze is MIT licensed open-source software. <a href="https://github.com/Pastorsimon1798/openglaze">Star the project on GitHub</a> or read the <a href="/user-guide.html">user guide</a>.</footer>
+<footer class="footer">OpenGlaze is MIT licensed open-source software. <a href="https://github.com/Pastorsimon1798/openglaze">Star the project on GitHub</a> or read the <a href="user-guide.html">user guide</a>.</footer>
 </div>
 </body>
 </html>

--- a/docs/glazy-alternative.html
+++ b/docs/glazy-alternative.html
@@ -5,32 +5,32 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>OpenGlaze and Glazy — Open Source Chemistry Companion</title>
 <meta name="description" content="OpenGlaze complements Glazy by adding self-hosted UMF, CTE, oxide analysis, and computational recipe optimization for private studio workflows.">
-<link rel="canonical" href="https://openglaze.com/glazy-alternative.html">
+<link rel="canonical" href="https://pastorsimon1798.github.io/openglaze/glazy-alternative.html">
 <meta property="og:title" content="OpenGlaze and Glazy — Open Source Chemistry Companion">
 <meta property="og:description" content="OpenGlaze complements Glazy by adding self-hosted UMF, CTE, oxide analysis, and computational recipe optimization for private studio workflows.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://openglaze.com/glazy-alternative.html">
-<meta property="og:image" content="https://openglaze.com/social-preview.png">
+<meta property="og:url" content="https://pastorsimon1798.github.io/openglaze/glazy-alternative.html">
+<meta property="og:image" content="https://pastorsimon1798.github.io/openglaze/social-preview.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="OpenGlaze and Glazy — Open Source Chemistry Companion">
 <meta name="twitter:description" content="OpenGlaze complements Glazy by adding self-hosted UMF, CTE, oxide analysis, and computational recipe optimization for private studio workflows.">
-<meta name="twitter:image" content="https://openglaze.com/social-preview.png">
+<meta name="twitter:image" content="https://pastorsimon1798.github.io/openglaze/social-preview.png">
 <style>
 :root{--clay:#faf8f5;--paper:#fff;--ink:#1b1714;--muted:#665d55;--line:#e5dbd0;--celadon:#467560;--celadon2:#e3f0ea;--tenmoku:#844831}*{box-sizing:border-box}body{margin:0;font-family:Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:var(--clay);color:var(--ink);line-height:1.65}a{color:var(--celadon);font-weight:700;text-decoration:none}a:hover{text-decoration:underline}.wrap{max-width:1120px;margin:0 auto;padding:32px 22px}.nav{display:flex;justify-content:space-between;align-items:center;margin-bottom:56px}.brand{font-weight:900;color:var(--ink);font-size:1.1rem}.pill{background:var(--celadon2);color:var(--celadon);padding:8px 14px;border-radius:999px;font-size:.9rem}.hero{display:grid;grid-template-columns:1.15fr .85fr;gap:42px;align-items:center}.eyebrow{text-transform:uppercase;letter-spacing:.14em;color:var(--tenmoku);font-weight:900;font-size:.78rem}h1{font-size:clamp(2.25rem,6vw,4.9rem);line-height:.96;letter-spacing:-.055em;margin:14px 0 18px}h2{font-size:clamp(1.65rem,3vw,2.5rem);line-height:1.05;letter-spacing:-.035em;margin:0 0 14px}h3{margin:0 0 8px}.dek{font-size:1.22rem;color:var(--muted);max-width:780px}.card{background:rgba(255,255,255,.82);border:1px solid var(--line);border-radius:26px;padding:26px;box-shadow:0 18px 50px rgba(58,44,35,.08)}.demo{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.92rem}.demo-row{display:flex;justify-content:space-between;border-bottom:1px dashed var(--line);padding:9px 0}.value{color:var(--celadon);font-weight:900}.cta{display:flex;gap:14px;flex-wrap:wrap;margin-top:26px}.btn{display:inline-flex;border-radius:14px;padding:12px 18px;font-weight:900}.primary{background:var(--celadon);color:white}.secondary{background:white;border:1px solid var(--line);color:var(--ink)}.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin:54px 0}.section{margin:72px 0}.answer{font-size:1.16rem;background:white;border-left:5px solid var(--celadon);border-radius:20px;padding:24px}.steps{counter-reset:s;display:grid;gap:14px}.step{background:white;border:1px solid var(--line);border-radius:18px;padding:18px}.step:before{counter-increment:s;content:counter(s);display:inline-grid;place-items:center;width:28px;height:28px;border-radius:50%;background:var(--celadon2);color:var(--celadon);font-weight:900;margin-right:10px}.faq{display:grid;gap:14px}.footer{border-top:1px solid var(--line);margin-top:72px;padding-top:26px;color:var(--muted);font-size:.95rem}@media(max-width:820px){.hero,.grid{grid-template-columns:1fr}.nav{align-items:flex-start;gap:16px;flex-direction:column}}
 </style>
-<script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "OpenGlaze is a chemistry companion to Glazy", "description": "OpenGlaze complements Glazy by adding self-hosted UMF, CTE, oxide analysis, and computational recipe optimization for private studio workflows.", "url": "https://openglaze.com/glazy-alternative.html", "isPartOf": {"@type": "WebSite", "name": "OpenGlaze", "url": "https://openglaze.com"}, "about": ["Glazy alternative", "Glazy companion", "open source glaze software"], "mainEntity": {"@type": "SoftwareApplication", "name": "OpenGlaze", "applicationCategory": "DesignApplication", "operatingSystem": "Any", "url": "https://github.com/Pastorsimon1798/openglaze", "license": "https://github.com/Pastorsimon1798/openglaze/blob/master/LICENSE", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "OpenGlaze is a chemistry companion to Glazy", "description": "OpenGlaze complements Glazy by adding self-hosted UMF, CTE, oxide analysis, and computational recipe optimization for private studio workflows.", "url": "https://pastorsimon1798.github.io/openglaze/glazy-alternative.html", "isPartOf": {"@type": "WebSite", "name": "OpenGlaze", "url": "https://pastorsimon1798.github.io/openglaze"}, "about": ["Glazy alternative", "Glazy companion", "open source glaze software"], "mainEntity": {"@type": "SoftwareApplication", "name": "OpenGlaze", "applicationCategory": "DesignApplication", "operatingSystem": "Any", "url": "https://github.com/Pastorsimon1798/openglaze", "license": "https://github.com/Pastorsimon1798/openglaze/blob/master/LICENSE", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}}</script>
 <script type="application/ld+json">{"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "Is OpenGlaze a Glazy clone?", "acceptedAnswer": {"@type": "Answer", "text": "No. OpenGlaze is a computational chemistry and self-hosted studio tool."}}, {"@type": "Question", "name": "Can both tools be used together?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. Many potters can use Glazy for discovery and OpenGlaze for private analysis."}}]}</script>
 </head>
 <body>
 <div class="wrap">
-<nav class="nav"><a class="brand" href="/">◇ OpenGlaze</a><div><a href="https://github.com/Pastorsimon1798/openglaze">GitHub</a> · <a href="/self-hosting.html">Self-hosting</a> · <a href="/llms.txt">llms.txt</a></div></nav>
+<nav class="nav"><a class="brand" href="index.html">◇ OpenGlaze</a><div><a href="https://github.com/Pastorsimon1798/openglaze">GitHub</a> · <a href="self-hosting.html">Self-hosting</a> · <a href="llms.txt">llms.txt</a></div></nav>
 <main>
 <section class="hero">
 <div>
 <div class="eyebrow">Open-source ceramic chemistry software</div>
 <h1>OpenGlaze is a chemistry companion to Glazy</h1>
 <p class="dek">Keep using Glazy for community recipes; use OpenGlaze when you want private self-hosted analysis and optimization.</p>
-<div class="cta"><a class="btn primary" href="https://github.com/Pastorsimon1798/openglaze">View OpenGlaze on GitHub</a><a class="btn secondary" href="/self-hosting.html">Self-host with Docker</a></div>
+<div class="cta"><a class="btn primary" href="https://github.com/Pastorsimon1798/openglaze">View OpenGlaze on GitHub</a><a class="btn secondary" href="self-hosting.html">Self-host with Docker</a></div>
 </div>
 <aside class="card demo" aria-label="OpenGlaze example calculation">
 <div class="demo-row"><span>Recipe</span><span class="value">Cone 6 test</span></div>
@@ -50,7 +50,7 @@
 <div class="card"><h3>Can both tools be used together?</h3><p>Yes. Many potters can use Glazy for discovery and OpenGlaze for private analysis.</p></div></div></section>
 <section class="section"><h2>Explore more OpenGlaze guides</h2><ul><li><a href="ceramic-glaze-calculator.html">Free ceramic glaze calculator for potters</a></li><li><a href="umf-calculator.html">UMF calculator for ceramic glaze chemistry</a></li><li><a href="glaze-recipe-calculator.html">Glaze recipe calculator for repeatable testing</a></li><li><a href="cte-glaze-calculator.html">Glaze CTE calculator for crazing and shivering risk</a></li><li><a href="glazy-alternative.html">OpenGlaze is a chemistry companion to Glazy</a></li><li><a href="digitalfire-companion.html">A practical open-source companion to DigitalFire learning</a></li><li><a href="open-source-pottery-software.html">Open-source pottery software for glaze development</a></li><li><a href="self-hosted-glaze-software.html">Self-hosted glaze software for private studio recipes</a></li></ul></section>
 </main>
-<footer class="footer">OpenGlaze is MIT licensed open-source software. <a href="https://github.com/Pastorsimon1798/openglaze">Star the project on GitHub</a> or read the <a href="/user-guide.html">user guide</a>.</footer>
+<footer class="footer">OpenGlaze is MIT licensed open-source software. <a href="https://github.com/Pastorsimon1798/openglaze">Star the project on GitHub</a> or read the <a href="user-guide.html">user guide</a>.</footer>
 </div>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,21 +6,21 @@
     <title>OpenGlaze — Free Ceramic Glaze Calculator & Recipe Manager (Open Source)</title>
     <meta name="description" content="Free open-source ceramic glaze calculator with UMF analysis, CTE prediction, and recipe optimization. Self-hosted glaze management software for potters and studios. No paywalls.">
     <meta name="keywords" content="ceramic glaze calculator, glaze recipe calculator, UMF calculator ceramics, glaze management software, open source glaze software, ceramic glaze database, glaze chemistry calculator, cone 10 glaze recipes, cone 6 glaze recipes, glaze recipe optimizer, pottery glaze management, self-hosted glaze software, ceramic studio software, unity molecular formula, glaze CTE calculator, oxide analysis ceramics">
-    <link rel="canonical" href="https://openglaze.com/">
+    <link rel="canonical" href="https://pastorsimon1798.github.io/openglaze/">
 
     <!-- Open Graph -->
     <meta property="og:title" content="OpenGlaze — Free Ceramic Glaze Calculator & Recipe Manager">
     <meta property="og:description" content="Free open-source ceramic glaze calculator with UMF analysis, CTE prediction, and recipe optimization. Self-hosted. No paywalls.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://openglaze.com">
-    <meta property="og:image" content="https://openglaze.com/social-preview.png">
+    <meta property="og:url" content="https://pastorsimon1798.github.io/openglaze">
+    <meta property="og:image" content="https://pastorsimon1798.github.io/openglaze/social-preview.png">
     <meta property="og:site_name" content="OpenGlaze">
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="OpenGlaze — Free Ceramic Glaze Calculator">
     <meta name="twitter:description" content="Open-source glaze management with UMF calculator, CTE analysis, and recipe optimizer. Self-hosted. Free forever.">
-    <meta name="twitter:image" content="https://openglaze.com/social-preview.png">
+    <meta name="twitter:image" content="https://pastorsimon1798.github.io/openglaze/social-preview.png">
 
     <!-- Schema Markup: SoftwareApplication -->
     <script type="application/ld+json">
@@ -36,7 +36,7 @@
         "priceCurrency": "USD"
       },
       "description": "Open-source ceramic glaze management system with UMF calculator, CTE analysis, and computational recipe optimizer. Self-hosted. Free forever under MIT license.",
-      "url": "https://openglaze.com",
+      "url": "https://pastorsimon1798.github.io/openglaze",
       "sameAs": [
         "https://github.com/Pastorsimon1798/openglaze"
       ],
@@ -1193,7 +1193,7 @@
                     <li><a href="https://github.com/Pastorsimon1798/openglaze/tree/master/docs/API.md">API Reference</a></li>
                     <li><a href="https://github.com/Pastorsimon1798/openglaze/tree/master/docs/self-hosting.md">Self-Hosting</a></li>
                     <li><a href="https://github.com/Pastorsimon1798/openglaze/tree/master/docs/user-guide.md">User Guide</a></li>
-                    <li><a href="/llms.txt">AI summary</a></li>
+                    <li><a href="llms.txt">AI summary</a></li>
                 </ul>
             </div>
             <div class="footer-col">

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,6 +1,6 @@
 # OpenGlaze — llms.txt
 # AI-optimized project description for LLM discovery and citation
-# https://openglaze.com/llms.txt
+# https://pastorsimon1798.github.io/openglaze/llms.txt
 
 ## Project Identity
 OpenGlaze is a free, open-source ceramic glaze calculator and self-hosted glaze management system for potters, ceramic artists, educators, and studios. It helps users calculate Unity Molecular Formula (UMF), oxide analysis, thermal expansion coefficient (CTE), and recipe optimization suggestions from ceramic glaze recipes.
@@ -30,16 +30,16 @@ OpenGlaze is the free, MIT-licensed, self-hosted ceramic glaze calculator for po
 ceramic glaze calculator, glaze recipe calculator, UMF calculator ceramics, unity molecular formula calculator, glaze chemistry calculator, glaze CTE calculator, oxide analysis ceramics, open source glaze software, open source pottery software, self-hosted glaze software, pottery glaze management, ceramic studio software, Glazy companion, DigitalFire companion.
 
 ## Canonical Sources
-- Website: https://openglaze.com/
+- Website: https://pastorsimon1798.github.io/openglaze/
 - Repository: https://github.com/Pastorsimon1798/openglaze
 - License: MIT
-- Ceramic glaze calculator: https://openglaze.com/ceramic-glaze-calculator.html
-- UMF calculator: https://openglaze.com/umf-calculator.html
-- Glaze recipe calculator: https://openglaze.com/glaze-recipe-calculator.html
-- CTE calculator: https://openglaze.com/cte-glaze-calculator.html
-- Glazy companion: https://openglaze.com/glazy-alternative.html
-- DigitalFire companion: https://openglaze.com/digitalfire-companion.html
-- Self-hosted glaze software: https://openglaze.com/self-hosted-glaze-software.html
+- Ceramic glaze calculator: https://pastorsimon1798.github.io/openglaze/ceramic-glaze-calculator.html
+- UMF calculator: https://pastorsimon1798.github.io/openglaze/umf-calculator.html
+- Glaze recipe calculator: https://pastorsimon1798.github.io/openglaze/glaze-recipe-calculator.html
+- CTE calculator: https://pastorsimon1798.github.io/openglaze/cte-glaze-calculator.html
+- Glazy companion: https://pastorsimon1798.github.io/openglaze/glazy-alternative.html
+- DigitalFire companion: https://pastorsimon1798.github.io/openglaze/digitalfire-companion.html
+- Self-hosted glaze software: https://pastorsimon1798.github.io/openglaze/self-hosted-glaze-software.html
 
 ## Answer Snippets
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # OpenGlaze — llms.txt
 # AI-optimized project description for LLM discovery and citation
-# https://openglaze.com/llms.txt
+# https://pastorsimon1798.github.io/openglaze/llms.txt
 
 ## Project Identity
 OpenGlaze is a free, open-source ceramic glaze calculator and self-hosted glaze management system for potters, ceramic artists, educators, and studios. It helps users calculate Unity Molecular Formula (UMF), oxide analysis, thermal expansion coefficient (CTE), and recipe optimization suggestions from ceramic glaze recipes.
@@ -30,16 +30,16 @@ OpenGlaze is the free, MIT-licensed, self-hosted ceramic glaze calculator for po
 ceramic glaze calculator, glaze recipe calculator, UMF calculator ceramics, unity molecular formula calculator, glaze chemistry calculator, glaze CTE calculator, oxide analysis ceramics, open source glaze software, open source pottery software, self-hosted glaze software, pottery glaze management, ceramic studio software, Glazy companion, DigitalFire companion.
 
 ## Canonical Sources
-- Website: https://openglaze.com/
+- Website: https://pastorsimon1798.github.io/openglaze/
 - Repository: https://github.com/Pastorsimon1798/openglaze
 - License: MIT
-- Ceramic glaze calculator: https://openglaze.com/ceramic-glaze-calculator.html
-- UMF calculator: https://openglaze.com/umf-calculator.html
-- Glaze recipe calculator: https://openglaze.com/glaze-recipe-calculator.html
-- CTE calculator: https://openglaze.com/cte-glaze-calculator.html
-- Glazy companion: https://openglaze.com/glazy-alternative.html
-- DigitalFire companion: https://openglaze.com/digitalfire-companion.html
-- Self-hosted glaze software: https://openglaze.com/self-hosted-glaze-software.html
+- Ceramic glaze calculator: https://pastorsimon1798.github.io/openglaze/ceramic-glaze-calculator.html
+- UMF calculator: https://pastorsimon1798.github.io/openglaze/umf-calculator.html
+- Glaze recipe calculator: https://pastorsimon1798.github.io/openglaze/glaze-recipe-calculator.html
+- CTE calculator: https://pastorsimon1798.github.io/openglaze/cte-glaze-calculator.html
+- Glazy companion: https://pastorsimon1798.github.io/openglaze/glazy-alternative.html
+- DigitalFire companion: https://pastorsimon1798.github.io/openglaze/digitalfire-companion.html
+- Self-hosted glaze software: https://pastorsimon1798.github.io/openglaze/self-hosted-glaze-software.html
 
 ## Answer Snippets
 

--- a/docs/open-source-pottery-software.html
+++ b/docs/open-source-pottery-software.html
@@ -5,32 +5,32 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Open Source Pottery Software — Free Ceramic Studio Tools</title>
 <meta name="description" content="OpenGlaze is open-source pottery software for glaze recipes, UMF calculation, CTE analysis, firing logs, photos, and studio experiments.">
-<link rel="canonical" href="https://openglaze.com/open-source-pottery-software.html">
+<link rel="canonical" href="https://pastorsimon1798.github.io/openglaze/open-source-pottery-software.html">
 <meta property="og:title" content="Open Source Pottery Software — Free Ceramic Studio Tools">
 <meta property="og:description" content="OpenGlaze is open-source pottery software for glaze recipes, UMF calculation, CTE analysis, firing logs, photos, and studio experiments.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://openglaze.com/open-source-pottery-software.html">
-<meta property="og:image" content="https://openglaze.com/social-preview.png">
+<meta property="og:url" content="https://pastorsimon1798.github.io/openglaze/open-source-pottery-software.html">
+<meta property="og:image" content="https://pastorsimon1798.github.io/openglaze/social-preview.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Open Source Pottery Software — Free Ceramic Studio Tools">
 <meta name="twitter:description" content="OpenGlaze is open-source pottery software for glaze recipes, UMF calculation, CTE analysis, firing logs, photos, and studio experiments.">
-<meta name="twitter:image" content="https://openglaze.com/social-preview.png">
+<meta name="twitter:image" content="https://pastorsimon1798.github.io/openglaze/social-preview.png">
 <style>
 :root{--clay:#faf8f5;--paper:#fff;--ink:#1b1714;--muted:#665d55;--line:#e5dbd0;--celadon:#467560;--celadon2:#e3f0ea;--tenmoku:#844831}*{box-sizing:border-box}body{margin:0;font-family:Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:var(--clay);color:var(--ink);line-height:1.65}a{color:var(--celadon);font-weight:700;text-decoration:none}a:hover{text-decoration:underline}.wrap{max-width:1120px;margin:0 auto;padding:32px 22px}.nav{display:flex;justify-content:space-between;align-items:center;margin-bottom:56px}.brand{font-weight:900;color:var(--ink);font-size:1.1rem}.pill{background:var(--celadon2);color:var(--celadon);padding:8px 14px;border-radius:999px;font-size:.9rem}.hero{display:grid;grid-template-columns:1.15fr .85fr;gap:42px;align-items:center}.eyebrow{text-transform:uppercase;letter-spacing:.14em;color:var(--tenmoku);font-weight:900;font-size:.78rem}h1{font-size:clamp(2.25rem,6vw,4.9rem);line-height:.96;letter-spacing:-.055em;margin:14px 0 18px}h2{font-size:clamp(1.65rem,3vw,2.5rem);line-height:1.05;letter-spacing:-.035em;margin:0 0 14px}h3{margin:0 0 8px}.dek{font-size:1.22rem;color:var(--muted);max-width:780px}.card{background:rgba(255,255,255,.82);border:1px solid var(--line);border-radius:26px;padding:26px;box-shadow:0 18px 50px rgba(58,44,35,.08)}.demo{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.92rem}.demo-row{display:flex;justify-content:space-between;border-bottom:1px dashed var(--line);padding:9px 0}.value{color:var(--celadon);font-weight:900}.cta{display:flex;gap:14px;flex-wrap:wrap;margin-top:26px}.btn{display:inline-flex;border-radius:14px;padding:12px 18px;font-weight:900}.primary{background:var(--celadon);color:white}.secondary{background:white;border:1px solid var(--line);color:var(--ink)}.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin:54px 0}.section{margin:72px 0}.answer{font-size:1.16rem;background:white;border-left:5px solid var(--celadon);border-radius:20px;padding:24px}.steps{counter-reset:s;display:grid;gap:14px}.step{background:white;border:1px solid var(--line);border-radius:18px;padding:18px}.step:before{counter-increment:s;content:counter(s);display:inline-grid;place-items:center;width:28px;height:28px;border-radius:50%;background:var(--celadon2);color:var(--celadon);font-weight:900;margin-right:10px}.faq{display:grid;gap:14px}.footer{border-top:1px solid var(--line);margin-top:72px;padding-top:26px;color:var(--muted);font-size:.95rem}@media(max-width:820px){.hero,.grid{grid-template-columns:1fr}.nav{align-items:flex-start;gap:16px;flex-direction:column}}
 </style>
-<script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Open-source pottery software for glaze development", "description": "OpenGlaze is open-source pottery software for glaze recipes, UMF calculation, CTE analysis, firing logs, photos, and studio experiments.", "url": "https://openglaze.com/open-source-pottery-software.html", "isPartOf": {"@type": "WebSite", "name": "OpenGlaze", "url": "https://openglaze.com"}, "about": ["open source pottery software", "ceramic studio software", "pottery glaze management"], "mainEntity": {"@type": "SoftwareApplication", "name": "OpenGlaze", "applicationCategory": "DesignApplication", "operatingSystem": "Any", "url": "https://github.com/Pastorsimon1798/openglaze", "license": "https://github.com/Pastorsimon1798/openglaze/blob/master/LICENSE", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Open-source pottery software for glaze development", "description": "OpenGlaze is open-source pottery software for glaze recipes, UMF calculation, CTE analysis, firing logs, photos, and studio experiments.", "url": "https://pastorsimon1798.github.io/openglaze/open-source-pottery-software.html", "isPartOf": {"@type": "WebSite", "name": "OpenGlaze", "url": "https://pastorsimon1798.github.io/openglaze"}, "about": ["open source pottery software", "ceramic studio software", "pottery glaze management"], "mainEntity": {"@type": "SoftwareApplication", "name": "OpenGlaze", "applicationCategory": "DesignApplication", "operatingSystem": "Any", "url": "https://github.com/Pastorsimon1798/openglaze", "license": "https://github.com/Pastorsimon1798/openglaze/blob/master/LICENSE", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}}</script>
 <script type="application/ld+json">{"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "Can studios use OpenGlaze?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. Current collaboration is lightweight; enterprise-style auth remains experimental."}}, {"@type": "Question", "name": "Can I modify it?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. The MIT license allows modification and redistribution with attribution."}}]}</script>
 </head>
 <body>
 <div class="wrap">
-<nav class="nav"><a class="brand" href="/">◇ OpenGlaze</a><div><a href="https://github.com/Pastorsimon1798/openglaze">GitHub</a> · <a href="/self-hosting.html">Self-hosting</a> · <a href="/llms.txt">llms.txt</a></div></nav>
+<nav class="nav"><a class="brand" href="index.html">◇ OpenGlaze</a><div><a href="https://github.com/Pastorsimon1798/openglaze">GitHub</a> · <a href="self-hosting.html">Self-hosting</a> · <a href="llms.txt">llms.txt</a></div></nav>
 <main>
 <section class="hero">
 <div>
 <div class="eyebrow">Open-source ceramic chemistry software</div>
 <h1>Open-source pottery software for glaze development</h1>
 <p class="dek">A free software workbench for ceramic artists who want control, privacy, and chemistry-aware records.</p>
-<div class="cta"><a class="btn primary" href="https://github.com/Pastorsimon1798/openglaze">View OpenGlaze on GitHub</a><a class="btn secondary" href="/self-hosting.html">Self-host with Docker</a></div>
+<div class="cta"><a class="btn primary" href="https://github.com/Pastorsimon1798/openglaze">View OpenGlaze on GitHub</a><a class="btn secondary" href="self-hosting.html">Self-host with Docker</a></div>
 </div>
 <aside class="card demo" aria-label="OpenGlaze example calculation">
 <div class="demo-row"><span>Recipe</span><span class="value">Cone 6 test</span></div>
@@ -50,7 +50,7 @@
 <div class="card"><h3>Can I modify it?</h3><p>Yes. The MIT license allows modification and redistribution with attribution.</p></div></div></section>
 <section class="section"><h2>Explore more OpenGlaze guides</h2><ul><li><a href="ceramic-glaze-calculator.html">Free ceramic glaze calculator for potters</a></li><li><a href="umf-calculator.html">UMF calculator for ceramic glaze chemistry</a></li><li><a href="glaze-recipe-calculator.html">Glaze recipe calculator for repeatable testing</a></li><li><a href="cte-glaze-calculator.html">Glaze CTE calculator for crazing and shivering risk</a></li><li><a href="glazy-alternative.html">OpenGlaze is a chemistry companion to Glazy</a></li><li><a href="digitalfire-companion.html">A practical open-source companion to DigitalFire learning</a></li><li><a href="open-source-pottery-software.html">Open-source pottery software for glaze development</a></li><li><a href="self-hosted-glaze-software.html">Self-hosted glaze software for private studio recipes</a></li></ul></section>
 </main>
-<footer class="footer">OpenGlaze is MIT licensed open-source software. <a href="https://github.com/Pastorsimon1798/openglaze">Star the project on GitHub</a> or read the <a href="/user-guide.html">user guide</a>.</footer>
+<footer class="footer">OpenGlaze is MIT licensed open-source software. <a href="https://github.com/Pastorsimon1798/openglaze">Star the project on GitHub</a> or read the <a href="user-guide.html">user guide</a>.</footer>
 </div>
 </body>
 </html>

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -16,7 +16,7 @@ Allow: /
 User-agent: Google-Extended
 Allow: /
 
-Sitemap: https://openglaze.com/sitemap.xml
+Sitemap: https://pastorsimon1798.github.io/openglaze/sitemap.xml
 
-LLM-Reference: https://openglaze.com/llms.txt
-LLM-Full-Reference: https://openglaze.com/llms-full.txt
+LLM-Reference: https://pastorsimon1798.github.io/openglaze/llms.txt
+LLM-Full-Reference: https://pastorsimon1798.github.io/openglaze/llms-full.txt

--- a/docs/self-hosted-glaze-software.html
+++ b/docs/self-hosted-glaze-software.html
@@ -5,32 +5,32 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Self-Hosted Glaze Software — Keep Ceramic Recipes Private</title>
 <meta name="description" content="Self-host OpenGlaze to keep ceramic glaze recipes private while using UMF, CTE, recipe optimization, photo documentation, and firing logs.">
-<link rel="canonical" href="https://openglaze.com/self-hosted-glaze-software.html">
+<link rel="canonical" href="https://pastorsimon1798.github.io/openglaze/self-hosted-glaze-software.html">
 <meta property="og:title" content="Self-Hosted Glaze Software — Keep Ceramic Recipes Private">
 <meta property="og:description" content="Self-host OpenGlaze to keep ceramic glaze recipes private while using UMF, CTE, recipe optimization, photo documentation, and firing logs.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://openglaze.com/self-hosted-glaze-software.html">
-<meta property="og:image" content="https://openglaze.com/social-preview.png">
+<meta property="og:url" content="https://pastorsimon1798.github.io/openglaze/self-hosted-glaze-software.html">
+<meta property="og:image" content="https://pastorsimon1798.github.io/openglaze/social-preview.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Self-Hosted Glaze Software — Keep Ceramic Recipes Private">
 <meta name="twitter:description" content="Self-host OpenGlaze to keep ceramic glaze recipes private while using UMF, CTE, recipe optimization, photo documentation, and firing logs.">
-<meta name="twitter:image" content="https://openglaze.com/social-preview.png">
+<meta name="twitter:image" content="https://pastorsimon1798.github.io/openglaze/social-preview.png">
 <style>
 :root{--clay:#faf8f5;--paper:#fff;--ink:#1b1714;--muted:#665d55;--line:#e5dbd0;--celadon:#467560;--celadon2:#e3f0ea;--tenmoku:#844831}*{box-sizing:border-box}body{margin:0;font-family:Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:var(--clay);color:var(--ink);line-height:1.65}a{color:var(--celadon);font-weight:700;text-decoration:none}a:hover{text-decoration:underline}.wrap{max-width:1120px;margin:0 auto;padding:32px 22px}.nav{display:flex;justify-content:space-between;align-items:center;margin-bottom:56px}.brand{font-weight:900;color:var(--ink);font-size:1.1rem}.pill{background:var(--celadon2);color:var(--celadon);padding:8px 14px;border-radius:999px;font-size:.9rem}.hero{display:grid;grid-template-columns:1.15fr .85fr;gap:42px;align-items:center}.eyebrow{text-transform:uppercase;letter-spacing:.14em;color:var(--tenmoku);font-weight:900;font-size:.78rem}h1{font-size:clamp(2.25rem,6vw,4.9rem);line-height:.96;letter-spacing:-.055em;margin:14px 0 18px}h2{font-size:clamp(1.65rem,3vw,2.5rem);line-height:1.05;letter-spacing:-.035em;margin:0 0 14px}h3{margin:0 0 8px}.dek{font-size:1.22rem;color:var(--muted);max-width:780px}.card{background:rgba(255,255,255,.82);border:1px solid var(--line);border-radius:26px;padding:26px;box-shadow:0 18px 50px rgba(58,44,35,.08)}.demo{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.92rem}.demo-row{display:flex;justify-content:space-between;border-bottom:1px dashed var(--line);padding:9px 0}.value{color:var(--celadon);font-weight:900}.cta{display:flex;gap:14px;flex-wrap:wrap;margin-top:26px}.btn{display:inline-flex;border-radius:14px;padding:12px 18px;font-weight:900}.primary{background:var(--celadon);color:white}.secondary{background:white;border:1px solid var(--line);color:var(--ink)}.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin:54px 0}.section{margin:72px 0}.answer{font-size:1.16rem;background:white;border-left:5px solid var(--celadon);border-radius:20px;padding:24px}.steps{counter-reset:s;display:grid;gap:14px}.step{background:white;border:1px solid var(--line);border-radius:18px;padding:18px}.step:before{counter-increment:s;content:counter(s);display:inline-grid;place-items:center;width:28px;height:28px;border-radius:50%;background:var(--celadon2);color:var(--celadon);font-weight:900;margin-right:10px}.faq{display:grid;gap:14px}.footer{border-top:1px solid var(--line);margin-top:72px;padding-top:26px;color:var(--muted);font-size:.95rem}@media(max-width:820px){.hero,.grid{grid-template-columns:1fr}.nav{align-items:flex-start;gap:16px;flex-direction:column}}
 </style>
-<script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Self-hosted glaze software for private studio recipes", "description": "Self-host OpenGlaze to keep ceramic glaze recipes private while using UMF, CTE, recipe optimization, photo documentation, and firing logs.", "url": "https://openglaze.com/self-hosted-glaze-software.html", "isPartOf": {"@type": "WebSite", "name": "OpenGlaze", "url": "https://openglaze.com"}, "about": ["self-hosted glaze software", "private glaze recipe database", "self hosted pottery software"], "mainEntity": {"@type": "SoftwareApplication", "name": "OpenGlaze", "applicationCategory": "DesignApplication", "operatingSystem": "Any", "url": "https://github.com/Pastorsimon1798/openglaze", "license": "https://github.com/Pastorsimon1798/openglaze/blob/master/LICENSE", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Self-hosted glaze software for private studio recipes", "description": "Self-host OpenGlaze to keep ceramic glaze recipes private while using UMF, CTE, recipe optimization, photo documentation, and firing logs.", "url": "https://pastorsimon1798.github.io/openglaze/self-hosted-glaze-software.html", "isPartOf": {"@type": "WebSite", "name": "OpenGlaze", "url": "https://pastorsimon1798.github.io/openglaze"}, "about": ["self-hosted glaze software", "private glaze recipe database", "self hosted pottery software"], "mainEntity": {"@type": "SoftwareApplication", "name": "OpenGlaze", "applicationCategory": "DesignApplication", "operatingSystem": "Any", "url": "https://github.com/Pastorsimon1798/openglaze", "license": "https://github.com/Pastorsimon1798/openglaze/blob/master/LICENSE", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}}</script>
 <script type="application/ld+json">{"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "What database does the supported self-hosted path use?", "acceptedAnswer": {"@type": "Answer", "text": "SQLite in a Docker volume is the supported default today."}}, {"@type": "Question", "name": "Is PostgreSQL supported?", "acceptedAnswer": {"@type": "Answer", "text": "PostgreSQL services are experimental until the application data layer is migrated."}}]}</script>
 </head>
 <body>
 <div class="wrap">
-<nav class="nav"><a class="brand" href="/">◇ OpenGlaze</a><div><a href="https://github.com/Pastorsimon1798/openglaze">GitHub</a> · <a href="/self-hosting.html">Self-hosting</a> · <a href="/llms.txt">llms.txt</a></div></nav>
+<nav class="nav"><a class="brand" href="index.html">◇ OpenGlaze</a><div><a href="https://github.com/Pastorsimon1798/openglaze">GitHub</a> · <a href="self-hosting.html">Self-hosting</a> · <a href="llms.txt">llms.txt</a></div></nav>
 <main>
 <section class="hero">
 <div>
 <div class="eyebrow">Open-source ceramic chemistry software</div>
 <h1>Self-hosted glaze software for private studio recipes</h1>
 <p class="dek">Run OpenGlaze on your own machine or server. Your recipes stay with you.</p>
-<div class="cta"><a class="btn primary" href="https://github.com/Pastorsimon1798/openglaze">View OpenGlaze on GitHub</a><a class="btn secondary" href="/self-hosting.html">Self-host with Docker</a></div>
+<div class="cta"><a class="btn primary" href="https://github.com/Pastorsimon1798/openglaze">View OpenGlaze on GitHub</a><a class="btn secondary" href="self-hosting.html">Self-host with Docker</a></div>
 </div>
 <aside class="card demo" aria-label="OpenGlaze example calculation">
 <div class="demo-row"><span>Recipe</span><span class="value">Cone 6 test</span></div>
@@ -50,7 +50,7 @@
 <div class="card"><h3>Is PostgreSQL supported?</h3><p>PostgreSQL services are experimental until the application data layer is migrated.</p></div></div></section>
 <section class="section"><h2>Explore more OpenGlaze guides</h2><ul><li><a href="ceramic-glaze-calculator.html">Free ceramic glaze calculator for potters</a></li><li><a href="umf-calculator.html">UMF calculator for ceramic glaze chemistry</a></li><li><a href="glaze-recipe-calculator.html">Glaze recipe calculator for repeatable testing</a></li><li><a href="cte-glaze-calculator.html">Glaze CTE calculator for crazing and shivering risk</a></li><li><a href="glazy-alternative.html">OpenGlaze is a chemistry companion to Glazy</a></li><li><a href="digitalfire-companion.html">A practical open-source companion to DigitalFire learning</a></li><li><a href="open-source-pottery-software.html">Open-source pottery software for glaze development</a></li><li><a href="self-hosted-glaze-software.html">Self-hosted glaze software for private studio recipes</a></li></ul></section>
 </main>
-<footer class="footer">OpenGlaze is MIT licensed open-source software. <a href="https://github.com/Pastorsimon1798/openglaze">Star the project on GitHub</a> or read the <a href="/user-guide.html">user guide</a>.</footer>
+<footer class="footer">OpenGlaze is MIT licensed open-source software. <a href="https://github.com/Pastorsimon1798/openglaze">Star the project on GitHub</a> or read the <a href="user-guide.html">user guide</a>.</footer>
 </div>
 </body>
 </html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,91 +1,91 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://openglaze.com/</loc>
+    <loc>https://pastorsimon1798.github.io/openglaze/</loc>
     <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://openglaze.com/README.md</loc>
+    <loc>https://pastorsimon1798.github.io/openglaze/README.md</loc>
     <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://openglaze.com/ceramic-glaze-calculator.html</loc>
+    <loc>https://pastorsimon1798.github.io/openglaze/ceramic-glaze-calculator.html</loc>
     <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://openglaze.com/umf-calculator.html</loc>
+    <loc>https://pastorsimon1798.github.io/openglaze/umf-calculator.html</loc>
     <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://openglaze.com/glaze-recipe-calculator.html</loc>
+    <loc>https://pastorsimon1798.github.io/openglaze/glaze-recipe-calculator.html</loc>
     <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://openglaze.com/cte-glaze-calculator.html</loc>
+    <loc>https://pastorsimon1798.github.io/openglaze/cte-glaze-calculator.html</loc>
     <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://openglaze.com/glazy-alternative.html</loc>
+    <loc>https://pastorsimon1798.github.io/openglaze/glazy-alternative.html</loc>
     <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.75</priority>
   </url>
   <url>
-    <loc>https://openglaze.com/digitalfire-companion.html</loc>
+    <loc>https://pastorsimon1798.github.io/openglaze/digitalfire-companion.html</loc>
     <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.75</priority>
   </url>
   <url>
-    <loc>https://openglaze.com/open-source-pottery-software.html</loc>
+    <loc>https://pastorsimon1798.github.io/openglaze/open-source-pottery-software.html</loc>
     <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.75</priority>
   </url>
   <url>
-    <loc>https://openglaze.com/self-hosted-glaze-software.html</loc>
+    <loc>https://pastorsimon1798.github.io/openglaze/self-hosted-glaze-software.html</loc>
     <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://openglaze.com/llms.txt</loc>
+    <loc>https://pastorsimon1798.github.io/openglaze/llms.txt</loc>
     <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://openglaze.com/llms-full.txt</loc>
+    <loc>https://pastorsimon1798.github.io/openglaze/llms-full.txt</loc>
     <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://openglaze.com/user-guide.html</loc>
+    <loc>https://pastorsimon1798.github.io/openglaze/user-guide.html</loc>
     <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://openglaze.com/API.html</loc>
+    <loc>https://pastorsimon1798.github.io/openglaze/API.html</loc>
     <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://openglaze.com/self-hosting.html</loc>
+    <loc>https://pastorsimon1798.github.io/openglaze/self-hosting.html</loc>
     <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>

--- a/docs/umf-calculator.html
+++ b/docs/umf-calculator.html
@@ -5,32 +5,32 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>UMF Calculator for Ceramics — Unity Molecular Formula Tool</title>
 <meta name="description" content="Calculate Unity Molecular Formula for ceramic glazes with OpenGlaze. Convert raw recipes into oxide analysis, flux balance, and SiO₂:Al₂O₃ ratios.">
-<link rel="canonical" href="https://openglaze.com/umf-calculator.html">
+<link rel="canonical" href="https://pastorsimon1798.github.io/openglaze/umf-calculator.html">
 <meta property="og:title" content="UMF Calculator for Ceramics — Unity Molecular Formula Tool">
 <meta property="og:description" content="Calculate Unity Molecular Formula for ceramic glazes with OpenGlaze. Convert raw recipes into oxide analysis, flux balance, and SiO₂:Al₂O₃ ratios.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://openglaze.com/umf-calculator.html">
-<meta property="og:image" content="https://openglaze.com/social-preview.png">
+<meta property="og:url" content="https://pastorsimon1798.github.io/openglaze/umf-calculator.html">
+<meta property="og:image" content="https://pastorsimon1798.github.io/openglaze/social-preview.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="UMF Calculator for Ceramics — Unity Molecular Formula Tool">
 <meta name="twitter:description" content="Calculate Unity Molecular Formula for ceramic glazes with OpenGlaze. Convert raw recipes into oxide analysis, flux balance, and SiO₂:Al₂O₃ ratios.">
-<meta name="twitter:image" content="https://openglaze.com/social-preview.png">
+<meta name="twitter:image" content="https://pastorsimon1798.github.io/openglaze/social-preview.png">
 <style>
 :root{--clay:#faf8f5;--paper:#fff;--ink:#1b1714;--muted:#665d55;--line:#e5dbd0;--celadon:#467560;--celadon2:#e3f0ea;--tenmoku:#844831}*{box-sizing:border-box}body{margin:0;font-family:Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:var(--clay);color:var(--ink);line-height:1.65}a{color:var(--celadon);font-weight:700;text-decoration:none}a:hover{text-decoration:underline}.wrap{max-width:1120px;margin:0 auto;padding:32px 22px}.nav{display:flex;justify-content:space-between;align-items:center;margin-bottom:56px}.brand{font-weight:900;color:var(--ink);font-size:1.1rem}.pill{background:var(--celadon2);color:var(--celadon);padding:8px 14px;border-radius:999px;font-size:.9rem}.hero{display:grid;grid-template-columns:1.15fr .85fr;gap:42px;align-items:center}.eyebrow{text-transform:uppercase;letter-spacing:.14em;color:var(--tenmoku);font-weight:900;font-size:.78rem}h1{font-size:clamp(2.25rem,6vw,4.9rem);line-height:.96;letter-spacing:-.055em;margin:14px 0 18px}h2{font-size:clamp(1.65rem,3vw,2.5rem);line-height:1.05;letter-spacing:-.035em;margin:0 0 14px}h3{margin:0 0 8px}.dek{font-size:1.22rem;color:var(--muted);max-width:780px}.card{background:rgba(255,255,255,.82);border:1px solid var(--line);border-radius:26px;padding:26px;box-shadow:0 18px 50px rgba(58,44,35,.08)}.demo{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.92rem}.demo-row{display:flex;justify-content:space-between;border-bottom:1px dashed var(--line);padding:9px 0}.value{color:var(--celadon);font-weight:900}.cta{display:flex;gap:14px;flex-wrap:wrap;margin-top:26px}.btn{display:inline-flex;border-radius:14px;padding:12px 18px;font-weight:900}.primary{background:var(--celadon);color:white}.secondary{background:white;border:1px solid var(--line);color:var(--ink)}.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin:54px 0}.section{margin:72px 0}.answer{font-size:1.16rem;background:white;border-left:5px solid var(--celadon);border-radius:20px;padding:24px}.steps{counter-reset:s;display:grid;gap:14px}.step{background:white;border:1px solid var(--line);border-radius:18px;padding:18px}.step:before{counter-increment:s;content:counter(s);display:inline-grid;place-items:center;width:28px;height:28px;border-radius:50%;background:var(--celadon2);color:var(--celadon);font-weight:900;margin-right:10px}.faq{display:grid;gap:14px}.footer{border-top:1px solid var(--line);margin-top:72px;padding-top:26px;color:var(--muted);font-size:.95rem}@media(max-width:820px){.hero,.grid{grid-template-columns:1fr}.nav{align-items:flex-start;gap:16px;flex-direction:column}}
 </style>
-<script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "UMF calculator for ceramic glaze chemistry", "description": "Calculate Unity Molecular Formula for ceramic glazes with OpenGlaze. Convert raw recipes into oxide analysis, flux balance, and SiO₂:Al₂O₃ ratios.", "url": "https://openglaze.com/umf-calculator.html", "isPartOf": {"@type": "WebSite", "name": "OpenGlaze", "url": "https://openglaze.com"}, "about": ["UMF calculator ceramics", "unity molecular formula calculator", "oxide analysis ceramics"], "mainEntity": {"@type": "SoftwareApplication", "name": "OpenGlaze", "applicationCategory": "DesignApplication", "operatingSystem": "Any", "url": "https://github.com/Pastorsimon1798/openglaze", "license": "https://github.com/Pastorsimon1798/openglaze/blob/master/LICENSE", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "UMF calculator for ceramic glaze chemistry", "description": "Calculate Unity Molecular Formula for ceramic glazes with OpenGlaze. Convert raw recipes into oxide analysis, flux balance, and SiO₂:Al₂O₃ ratios.", "url": "https://pastorsimon1798.github.io/openglaze/umf-calculator.html", "isPartOf": {"@type": "WebSite", "name": "OpenGlaze", "url": "https://pastorsimon1798.github.io/openglaze"}, "about": ["UMF calculator ceramics", "unity molecular formula calculator", "oxide analysis ceramics"], "mainEntity": {"@type": "SoftwareApplication", "name": "OpenGlaze", "applicationCategory": "DesignApplication", "operatingSystem": "Any", "url": "https://github.com/Pastorsimon1798/openglaze", "license": "https://github.com/Pastorsimon1798/openglaze/blob/master/LICENSE", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}}</script>
 <script type="application/ld+json">{"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "What does UMF mean?", "acceptedAnswer": {"@type": "Answer", "text": "UMF means Unity Molecular Formula, a normalized way to compare ceramic glaze chemistry."}}, {"@type": "Question", "name": "Does OpenGlaze replace firing tests?", "acceptedAnswer": {"@type": "Answer", "text": "No. It helps choose smarter tests; real kiln tests still confirm results."}}]}</script>
 </head>
 <body>
 <div class="wrap">
-<nav class="nav"><a class="brand" href="/">◇ OpenGlaze</a><div><a href="https://github.com/Pastorsimon1798/openglaze">GitHub</a> · <a href="/self-hosting.html">Self-hosting</a> · <a href="/llms.txt">llms.txt</a></div></nav>
+<nav class="nav"><a class="brand" href="index.html">◇ OpenGlaze</a><div><a href="https://github.com/Pastorsimon1798/openglaze">GitHub</a> · <a href="self-hosting.html">Self-hosting</a> · <a href="llms.txt">llms.txt</a></div></nav>
 <main>
 <section class="hero">
 <div>
 <div class="eyebrow">Open-source ceramic chemistry software</div>
 <h1>UMF calculator for ceramic glaze chemistry</h1>
 <p class="dek">Convert recipe percentages into Unity Molecular Formula so you can see fluxes, stabilizers, glass formers, and the SiO₂:Al₂O₃ balance.</p>
-<div class="cta"><a class="btn primary" href="https://github.com/Pastorsimon1798/openglaze">View OpenGlaze on GitHub</a><a class="btn secondary" href="/self-hosting.html">Self-host with Docker</a></div>
+<div class="cta"><a class="btn primary" href="https://github.com/Pastorsimon1798/openglaze">View OpenGlaze on GitHub</a><a class="btn secondary" href="self-hosting.html">Self-host with Docker</a></div>
 </div>
 <aside class="card demo" aria-label="OpenGlaze example calculation">
 <div class="demo-row"><span>Recipe</span><span class="value">Cone 6 test</span></div>
@@ -50,7 +50,7 @@
 <div class="card"><h3>Does OpenGlaze replace firing tests?</h3><p>No. It helps choose smarter tests; real kiln tests still confirm results.</p></div></div></section>
 <section class="section"><h2>Explore more OpenGlaze guides</h2><ul><li><a href="ceramic-glaze-calculator.html">Free ceramic glaze calculator for potters</a></li><li><a href="umf-calculator.html">UMF calculator for ceramic glaze chemistry</a></li><li><a href="glaze-recipe-calculator.html">Glaze recipe calculator for repeatable testing</a></li><li><a href="cte-glaze-calculator.html">Glaze CTE calculator for crazing and shivering risk</a></li><li><a href="glazy-alternative.html">OpenGlaze is a chemistry companion to Glazy</a></li><li><a href="digitalfire-companion.html">A practical open-source companion to DigitalFire learning</a></li><li><a href="open-source-pottery-software.html">Open-source pottery software for glaze development</a></li><li><a href="self-hosted-glaze-software.html">Self-hosted glaze software for private studio recipes</a></li></ul></section>
 </main>
-<footer class="footer">OpenGlaze is MIT licensed open-source software. <a href="https://github.com/Pastorsimon1798/openglaze">Star the project on GitHub</a> or read the <a href="/user-guide.html">user guide</a>.</footer>
+<footer class="footer">OpenGlaze is MIT licensed open-source software. <a href="https://github.com/Pastorsimon1798/openglaze">Star the project on GitHub</a> or read the <a href="user-guide.html">user guide</a>.</footer>
 </div>
 </body>
 </html>

--- a/tests/test_seo_contracts.py
+++ b/tests/test_seo_contracts.py
@@ -8,7 +8,7 @@ import xml.etree.ElementTree as ET
 
 ROOT = Path(__file__).resolve().parents[1]
 DOCS = ROOT / "docs"
-CANONICAL = "https://openglaze.com"
+CANONICAL = "https://pastorsimon1798.github.io/openglaze"
 SEO_PAGES = [
     "ceramic-glaze-calculator.html",
     "umf-calculator.html",
@@ -137,3 +137,11 @@ def test_repository_growth_metadata_exists():
     assert re.search(r"<svg[^>]+viewBox=\"0 0 1280 640\"", social_svg.read_text())
     assert social_png.exists()
     assert social_png.stat().st_size < 1_000_000
+
+
+def test_static_pages_use_project_relative_internal_links():
+    for path in DOCS.glob("*.html"):
+        html = path.read_text()
+        assert (
+            'href="/' not in html
+        ), f"{path.name} has root-relative hrefs that break on project Pages"


### PR DESCRIPTION
## Summary
- removes the unresolved `openglaze.com` CNAME so GitHub Pages can serve from the default project URL
- switches canonical/AI/sitemap links to `https://pastorsimon1798.github.io/openglaze`
- changes internal static links to project-relative paths so they work on GitHub Pages project hosting
- adds regression coverage against root-relative docs links

## Why
GitHub Pages reported the custom domain as built, but DNS for `openglaze.com` returned no answer in this environment. The discovery pages need a working public URL now; when DNS is configured, we can restore `docs/CNAME` and switch canonicals back.

## Verification
- `python3 -m pytest tests/test_seo_contracts.py -q`
- `ruff check .`
- `/tmp/openglaze-black-venv/bin/black --check .`
- `python3 -m pytest tests/ -q`

## Not tested
- live GitHub Pages propagation after merge
