### PR TITLE
Keep homepage discovery claims current

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -891,7 +891,7 @@
             </div>
             <div class="hero-stats">
                 <div class="hero-stat">
-                    <strong>111</strong>
+                    <strong>126</strong>
                     <span>Tests passing</span>
                 </div>
                 <div class="hero-stat">
@@ -974,7 +974,7 @@
             <div class="feature-card">
                 <div class="feature-icon" style="background: #e0e8f4;">🧮</div>
                 <h3>Recipe Optimizer</h3>
-                <p>Computes exact material adjustments to hit target CTE, surface, or durability — without firing test tiles.</p>
+                <p>Computes exact material adjustments to hit target CTE, surface, or durability — before firing test tiles.</p>
             </div>
             <div class="feature-card">
                 <div class="feature-icon" style="background: #e8e0f4;">🧠</div>

--- a/tests/test_seo_contracts.py
+++ b/tests/test_seo_contracts.py
@@ -145,3 +145,11 @@ def test_static_pages_use_project_relative_internal_links():
         assert (
             'href="/' not in html
         ), f"{path.name} has root-relative hrefs that break on project Pages"
+
+
+def test_homepage_visible_stats_are_current():
+    homepage = (DOCS / "index.html").read_text()
+    assert "<strong>126</strong>" in homepage
+    assert "<span>Tests passing</span>" in homepage
+    assert "111 Tests passing" not in homepage
+    assert "without firing test tiles" not in homepage


### PR DESCRIPTION
## Summary
- updates the homepage hero test count from 111 to the verified 126
- softens the optimizer copy from "without firing test tiles" to "before firing test tiles"
- adds SEO contract coverage so stale homepage stats/overclaims are caught

## Verification
- `python3 -m pytest tests/test_seo_contracts.py -q`
- `ruff check .`
- `/tmp/openglaze-black-venv/bin/black --check .`
- `python3 -m pytest tests/ -q`
