### PR TITLE
chore(deps): update Flask requirement to >=3.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cryptography>=41.0.0
 debugpy>=1.8.0
 flask-cors>=6.0.2
-Flask>=3.0.0
+Flask>=3.1.3
 gunicorn>=25.3.0
 psycopg2-binary>=2.9.9
 pytest>=9.0.3


### PR DESCRIPTION
## Summary
- applies the remaining Dependabot Flask floor update on top of current `master`
- resolves the conflict from PR #13 after the other dependency updates landed

## Verification
- `ruff check .`
- `/tmp/openglaze-black-venv/bin/black --check .`
- `python3 -m pytest tests/ -q`
