### PR TITLE
Use Codecov v6 coverage file input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         uses: codecov/codecov-action@v6
         if: matrix.python-version == '3.12'
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: false
 
   docker:

--- a/tests/test_launch_contracts.py
+++ b/tests/test_launch_contracts.py
@@ -105,3 +105,10 @@ def test_runtime_ports_and_cors_defaults_match_documented_docker_port():
 def test_experimental_cloud_env_names_postgres_host():
     env = (ROOT / ".env.example").read_text()
     assert "POSTGRES_HOST=postgres" in env
+
+
+def test_codecov_action_uses_v6_input_name():
+    ci = (ROOT / ".github/workflows/ci.yml").read_text()
+    assert "codecov/codecov-action@v6" in ci
+    assert "files: ./coverage.xml" in ci
+    assert "file: ./coverage.xml" not in ci


### PR DESCRIPTION
## Summary
- changes Codecov v6 config from deprecated/invalid `file` to `files`
- adds CI workflow contract coverage so the warning does not return

## Verification
- `python3 -m pytest tests/test_launch_contracts.py -q`
- `ruff check .`
- `/tmp/openglaze-black-venv/bin/black --check .`
- `python3 -m pytest tests/ -q`
