### PR TITLE
Use Blacksmith Linux for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     strategy:
       matrix:
         python-version: ['3.12', '3.13', '3.14']
@@ -52,7 +52,7 @@ jobs:
           fail_ci_if_error: false
 
   docker:
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: test
     if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
 
@@ -80,7 +80,7 @@ jobs:
           exit 1
 
   security:
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary\n- route openglaze test/security/docker CI from the broken self-hosted macOS runner to Blacksmith Linux\n- preserve the existing Python matrix and docker push gating\n\n## Why\nCurrent PRs fail before project checks run because actions/setup-python tries to create /Users/runner on the self-hosted macOS runner and gets permission denied. KyaniteLabs repos should use Blacksmith for ordinary build/test/security capacity.\n\n## Verification\n- python3.14 venv\n- black --check --diff .\n- ruff check .\n- pytest tests/ -q: 166 passed\n\nFixes KyaniteLabs/openglaze#30\nFixes KyaniteLabs/openglaze#31\nFixes KyaniteLabs/openglaze#32\nFixes KyaniteLabs/openglaze#33\nFixes KyaniteLabs/openglaze#34\nFixes KyaniteLabs/openglaze#35\nFixes KyaniteLabs/openglaze#36\nFixes KyaniteLabs/openglaze#37

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/openglaze/pr/38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->