### PR TITLE
Run workflows on Blacksmith

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- move repo-local workflow jobs off mixed self-hosted/GitHub-hosted runners
- use `blacksmith-2vcpu-ubuntu-2404` for the changed workflow jobs
- keep workflow and job names intact so required check contexts remain stable

## Changed workflows
- `.github/workflows/release.yml`

## Verification
- parsed changed workflow YAML locally

## Context
This repo was in a mixed Kyanite state: Blacksmith was present, but some repo-local workflows still targeted non-Blacksmith runners and could queue/block PRs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/openglaze/pr/39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->