### PR TITLE
Enable CodeRabbit public OSS review config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  review_details: false
+  auto_review:
+    enabled: true
+    drafts: false
+chat:
+  auto_reply: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,4 +109,4 @@ jobs:
         run: bandit -r . -f json -o bandit-report.json --exclude ./venv || true
 
       - name: Check dependencies for known vulnerabilities
-        run: safety check
+        run: safety check --ignore-file .safety-policy.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install bandit safety
+          pip install -r requirements-dev.txt
 
       - name: Run Bandit security scan
         run: bandit -r . -f json -o bandit-report.json --exclude ./venv || true
 
       - name: Check dependencies for known vulnerabilities
-        run: safety check --ignore-file .safety-policy.yml
+        run: safety --disable-optional-telemetry check --policy-file .safety-policy.yml -r requirements-dev.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,4 +109,6 @@ jobs:
         run: bandit -r . -f json -o bandit-report.json --exclude ./venv || true
 
       - name: Check dependencies for known vulnerabilities
+        env:
+          SAFETY_API_KEY: ${{ secrets.SAFETY_API_KEY }}
         run: safety --disable-optional-telemetry check --policy-file .safety-policy.yml -r requirements-dev.txt

--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,0 +1,14 @@
+project:
+  id: ''
+organization:
+  id: ''
+  name: ''
+security:
+  ignore-unpinned-requirements: True
+  ignore-cvss-severity-below: 0
+  ignore-cvss-unknown-severity: False
+  ignore-vulnerabilities: {}
+  continue-on-vulnerability-error: False
+security-updates:
+  auto-security-updates-limit:
+    - patch

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,4 @@ black>=26.3.1
 ruff>=0.15.12
 pytest-cov>=7.1.0
 bandit>=1.9.4
-safety>=3.7.0,<4.0.0
-authlib>=1.3.0
+safety==3.7.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ black>=26.3.1
 ruff>=0.15.12
 pytest-cov>=7.1.0
 bandit>=1.9.4
-safety>=3.7.0
+safety>=3.7.0,<4.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ ruff>=0.15.12
 pytest-cov>=7.1.0
 bandit>=1.9.4
 safety>=3.7.0,<4.0.0
+authlib>=1.3.0


### PR DESCRIPTION
Adds the public OSS CodeRabbit configuration only for this public repository.

Private repositories are intentionally excluded from this rollout so the free/public OSS lane stays separate from paid review capacity.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/openglaze/pr/98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration to adjust review behavior, enable auto-review and chat auto-replies, and change review verbosity.
  * Pinned a development-only security tool to a specific version.
  * Modified CI vulnerability scanning to install dev dependencies and run the scanner with a project-specific security policy and telemetry disabled.
* **Note**
  * No user-facing features or behavior changed; internal tooling updates only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KyaniteLabs/openglaze/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->