### PR TITLE
chore: harden public repo hygiene

### DIFF
--- a/.checkyourself.yml
+++ b/.checkyourself.yml
@@ -1,0 +1,12 @@
+version: 1
+suppress:
+  - id: Possible secret-like field without credential shape
+    reason: OpenGlaze intentionally names session/auth token variables in runtime cookie, localStorage, and token-generation paths; reviewed sites contain token handling code, not committed credential literals.
+    files:
+      - core/auth/middleware.py
+      - core/auth/simple_auth.py
+      - frontend/scripts/PhotoUploadForm.js
+      - frontend/scripts/api.js
+      - frontend/scripts/components/StudioPanel.js
+    reviewed_by: KyaniteLabs
+    reviewed_at: "2026-05-29"

--- a/.github/workflows/agent-law.yml
+++ b/.github/workflows/agent-law.yml
@@ -15,7 +15,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Verify Empower Orchestrator law
         shell: bash

--- a/.github/workflows/blacksmith-probe.yml
+++ b/.github/workflows/blacksmith-probe.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   probe:
-    uses: KyaniteLabs/.github/.github/workflows/blacksmith-probe.yml@main
+    uses: KyaniteLabs/.github/.github/workflows/blacksmith-probe.yml@c8c6d2670780cee864a6993fec223b191b70e3ee # main as of 2026-05-29
     with:
       probe_label: complementary-runner-probe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -54,7 +56,7 @@ jobs:
         run: pytest tests/ -v --cov=. --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         if: matrix.python-version == '3.12'
         with:
           files: ./coverage.xml
@@ -68,6 +70,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
@@ -94,6 +98,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -35,7 +37,7 @@ jobs:
           echo "image=ghcr.io/${{ github.repository_owner }}/openglaze" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           push: true
@@ -46,7 +48,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           generate_release_notes: true
           body: |

--- a/tests/test_launch_contracts.py
+++ b/tests/test_launch_contracts.py
@@ -99,7 +99,7 @@ def test_experimental_cloud_env_names_postgres_host():
 
 def test_codecov_action_uses_v6_input_name():
     ci = (ROOT / ".github/workflows/ci.yml").read_text()
-    assert "codecov/codecov-action@v6" in ci
+    assert "codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6" in ci
     assert "files: ./coverage.xml" in ci
     assert "file: ./coverage.xml" not in ci
 


### PR DESCRIPTION
## Summary
- pin mutable workflow actions/reusable workflows to immutable SHAs and disable checkout credential persistence
- add a reviewed CheckYourself suppression for runtime auth/session token handling sites
- update the launch contract so Codecov stays pinned while preserving the v6 `files:` input check
- archive and delete stale remote branch `fix/dual-provider-llm` after confirming dual-provider support already landed on `master` via #51

## Verification
- `python3 -m venv .venv && pip install -r requirements-dev.txt`
- `black --check --diff .`
- `ruff check .`
- `pytest tests/ -v --cov=. --cov-report=xml --cov-report=term` (166 passed)
- `safety --disable-optional-telemetry check --policy-file .safety-policy.yml -r requirements-dev.txt`
- `bandit -r . -x ./.venv,./venv -f json -o bandit-report.json || true` (existing findings only; CI is advisory)
- `gitleaks dir . --no-banner --redact --exit-code 1`
- CheckYourself deep scan: P0/P1/P2/P3 = 0, suppression_count = 1
- workflow YAML parse
- `git diff --check`

## Note
- Local Docker daemon is unavailable in this session, so the hosted CI Docker job is the source of truth for Docker smoke.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/openglaze/pr/108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782682206&installation_id=130430723&pr_number=108&repository=KyaniteLabs%2Fopenglaze&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fopenglaze%2Fpull%2F108&signature=a4a0e568c0b35a5c20e1915e5e0cd9b3ca2c3e5822740f1e8a58638b5ef3e069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Pinned GitHub Actions and workflows to specific versions across CI/CD pipelines
  * Disabled credential persistence during checkout operations
  * Updated secret detection and suppression configuration

* **Chores**
  * Refined CI workflow configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KyaniteLabs/openglaze/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->