### PR TITLE
docs: add KyaniteLabs cross-link footer (SEO/internal linking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ Questions, bug reports, and feature requests:
 
 ## Part of KyaniteLabs
 
-Open-source tools by [KyaniteLabs](https://kyanitelabs.tech). Related projects:
+More from [KyaniteLabs](https://kyanitelabs.tech). Related projects:
 
 - **[Innerscape](https://github.com/KyaniteLabs/Innerscape)** — personal-growth OS: journaling & reflection
 - **[Elixis](https://github.com/KyaniteLabs/Elixis)** — local-first AI pattern-synthesis engine for ideas

--- a/README.md
+++ b/README.md
@@ -441,3 +441,15 @@ Questions, bug reports, and feature requests:
   <a href="https://github.com/KyaniteLabs/openglaze/discussions">Discussions</a> •
   <a href="https://openglaze.kyanitelabs.tech">Website</a>
 </p>
+
+---
+
+## Part of KyaniteLabs
+
+Open-source tools by [KyaniteLabs](https://kyanitelabs.tech). Related projects:
+
+- **[Innerscape](https://github.com/KyaniteLabs/Innerscape)** — personal-growth OS: journaling & reflection
+- **[Elixis](https://github.com/KyaniteLabs/Elixis)** — local-first AI pattern-synthesis engine for ideas
+- **[liminal](https://github.com/KyaniteLabs/liminal)** — AI creative-coding studio (p5.js, GLSL, Three.js)
+
+→ More at **[kyanitelabs.tech](https://kyanitelabs.tech)**


### PR DESCRIPTION
## Why
Internal linking strengthens SEO/GEO authority flow between KyaniteLabs projects and surfaces related open-source tools to readers. Additive and low-maintenance.

## What changed
- Added a consistent **Part of KyaniteLabs** footer to `README.md` linking to 3 related projects + kyanitelabs.tech.
- Docs only — no code, dependencies, or behavior change.

## Verification
- Footer diff rendered; all links resolve to valid repos and the live site.
- License-accurate wording (neutral "More from KyaniteLabs", since some repos are BSL/source-available, not open-source).
- CI green.

## Maintainer checklist
- [x] Docs-only change
- [x] No code/behavior change
- [x] Links + license wording verified