### PR TITLE
Add CLI, MCP, and skill surfaces

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "openglaze": {
+      "command": "python",
+      "args": ["-m", "openglaze_mcp"]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,14 @@ See KyaniteLabs/.github for org-wide rules. Project-specific rules below:
 
 This is the **openglaze** repository. It is Free open-source ceramic glaze calculator, UMF analyzer, and recipe manager for potters and studios..
 
+## Agent Surfaces
+
+- CLI: `python -m openglaze_cli brief`, `python -m openglaze_cli umf --recipe "..."`
+- MCP: `python -m openglaze_mcp` starts the stdio MCP server.
+- Skill: `skills/openglaze/SKILL.md` is the public skill for glaze chemistry agent workflows.
+
+Keep CLI, MCP tools, README examples, and the public skill aligned when chemistry workflows change.
+
 # KyaniteLabs Engineering Rules
 
 This file provides operating instructions for all AI coding agents working in KyaniteLabs repositories. It is the AGENTS.md mirror of CLAUDE.md — both files contain identical rules.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,34 @@ python server.py
 
 Open http://localhost:8768 in your browser. (Docker default; manual install defaults to 8767.)
 
+### CLI, MCP, and Agent Skill
+
+OpenGlaze also ships agent-friendly local surfaces:
+
+```bash
+python -m openglaze_cli brief
+python -m openglaze_cli umf --recipe "Custer Feldspar 45, Silica 25, Whiting 18, EPK 12" --cone 10
+python -m openglaze_cli batch --recipe "Custer Feldspar 45, Silica 25, Whiting 18, EPK 12" --size 500
+python -m openglaze_mcp
+```
+
+- CLI: `python -m openglaze_cli` exposes project brief, UMF, batch scaling, and substitutions.
+- MCP: `python -m openglaze_mcp` starts a stdio MCP server with glaze recipe tools for agent hosts.
+- Skill: [`skills/openglaze/SKILL.md`](skills/openglaze/SKILL.md) guides compatible agents on when to use the CLI or MCP server and how to keep glaze-safety claims bounded.
+
+Example MCP config:
+
+```json
+{
+  "mcpServers": {
+    "openglaze": {
+      "command": "python",
+      "args": ["-m", "openglaze_mcp"]
+    }
+  }
+}
+```
+
 ## Features
 
 <table>

--- a/core/chemistry/umf.py
+++ b/core/chemistry/umf.py
@@ -6,7 +6,7 @@ normalized to flux total = 1.0. Provides surface prediction and limit checking.
 
 import logging
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from .materials import (
     get_material,
@@ -38,7 +38,32 @@ _LIMIT_FORMULAS_DEFAULT: Dict[str, tuple] = {
 }
 
 
-def get_limit_formulas(cone: int = 10) -> Dict[str, tuple]:
+def _cone_key_candidates(cone: Any) -> list[str]:
+    raw = str(cone).strip().lower().removeprefix("cone").strip("_- ")
+    if not raw:
+        raw = "10"
+
+    candidates = [f"cone_{raw}"]
+    if raw.isdigit():
+        as_int = int(raw)
+        unpadded = f"cone_{as_int}"
+        for key in (unpadded,):
+            if key not in candidates:
+                candidates.append(key)
+    return candidates
+
+
+def _cone_threshold_number(cone: Any) -> int:
+    raw = str(cone).strip().lower().removeprefix("cone").strip("_- ")
+    if raw.startswith("0") and len(raw) > 1:
+        return 0
+    try:
+        return int(raw)
+    except ValueError:
+        return 10
+
+
+def get_limit_formulas(cone: int | str = 10) -> Dict[str, tuple]:
     """Get UMF limit formulas for a specific cone.
 
     Loads cone-specific ranges from ceramics-foundation if available,
@@ -46,8 +71,9 @@ def get_limit_formulas(cone: int = 10) -> Dict[str, tuple]:
     """
     umf_data = load_umf_targets()
     if umf_data and "ranges" in umf_data:
-        cone_key = f"cone_{cone}"
-        if cone_key in umf_data["ranges"]:
+        for cone_key in _cone_key_candidates(cone):
+            if cone_key not in umf_data["ranges"]:
+                continue
             cone_ranges = umf_data["ranges"][cone_key]
             formulas = {}
             for oxide, bounds in cone_ranges.items():
@@ -58,7 +84,7 @@ def get_limit_formulas(cone: int = 10) -> Dict[str, tuple]:
     return dict(_LIMIT_FORMULAS_DEFAULT)
 
 
-def _get_surface_thresholds(cone: Optional[int] = None) -> Tuple[float, float]:
+def _get_surface_thresholds(cone: Optional[int | str] = None) -> Tuple[float, float]:
     """Get surface prediction thresholds for a given cone.
 
     Low-fire glazes need more flux to mature, so they appear glossier
@@ -71,12 +97,13 @@ def _get_surface_thresholds(cone: Optional[int] = None) -> Tuple[float, float]:
         # Find the best matching cone range
         cone_ranges = data["cone_thresholds"]
         if cone is not None:
+            cone_number = _cone_threshold_number(cone)
             # Map cone to range key
-            if cone <= 3:
+            if cone_number <= 3:
                 key = "low_fire"
-            elif cone <= 6:
+            elif cone_number <= 6:
                 key = "mid_range"
-            elif cone <= 11:
+            elif cone_number <= 11:
                 key = "high_fire"
             else:
                 key = "high_fire"
@@ -115,7 +142,7 @@ class UMFResult:
     warnings: List[str] = field(default_factory=list)
     error: Optional[str] = None
     missing_materials: List[str] = field(default_factory=list)
-    cone: Optional[int] = None
+    cone: Optional[int | str] = None
     confidence: Dict[str, str] = field(default_factory=dict)
     recommendations: List[str] = field(default_factory=list)
 
@@ -151,7 +178,9 @@ class UMFResult:
 class UMFAnalyzer:
     """Calculate Unity Molecular Formula from glaze recipes."""
 
-    def calculate(self, recipe_string: str, cone: Optional[int] = None) -> UMFResult:
+    def calculate(
+        self, recipe_string: str, cone: Optional[int | str] = None
+    ) -> UMFResult:
         """Calculate UMF from a recipe string.
 
         Args:
@@ -417,7 +446,7 @@ class UMFAnalyzer:
 
         return surface, confidence
 
-    def _check_limits(self, umf: Dict[str, float], cone: int) -> List[str]:
+    def _check_limits(self, umf: Dict[str, float], cone: int | str) -> List[str]:
         """Check UMF values against cone-specific target formula guidelines.
 
         Note: these are guidelines based on common ranges for the target cone,
@@ -622,7 +651,7 @@ class UMFAnalyzer:
 _analyzer = UMFAnalyzer()
 
 
-def calculate_umf(recipe: str, cone: Optional[int] = None) -> UMFResult:
+def calculate_umf(recipe: str, cone: Optional[int | str] = None) -> UMFResult:
     """Calculate UMF from a recipe string using the default analyzer.
 
     Args:

--- a/openglaze_cli.py
+++ b/openglaze_cli.py
@@ -16,6 +16,13 @@ def _print_json(payload: dict[str, Any]) -> None:
     print(json.dumps(payload, indent=2, sort_keys=True))
 
 
+def _parse_cone(value: Any) -> int | str:
+    raw = str(value).strip()
+    if raw.startswith("0") and len(raw) > 1:
+        return raw
+    return int(raw)
+
+
 def _project_brief() -> dict[str, Any]:
     return {
         "name": "OpenGlaze",
@@ -51,7 +58,9 @@ def main() -> None:
         help="Recipe string, e.g. 'Custer Feldspar 45, Silica 25, Whiting 18, EPK 12'.",
     )
     umf.add_argument(
-        "--cone", type=int, default=10, help="Firing cone. Defaults to 10."
+        "--cone",
+        default="10",
+        help='Firing cone. Use leading zero for low-fire cones, e.g. "04". Defaults to 10.',
     )
 
     batch = subparsers.add_parser("batch", help="Scale a recipe to a test batch.")
@@ -73,7 +82,7 @@ def main() -> None:
     if args.command == "brief":
         _print_json(_project_brief())
     elif args.command == "umf":
-        _print_json(calculate_umf(args.recipe, cone=args.cone).to_dict())
+        _print_json(calculate_umf(args.recipe, cone=_parse_cone(args.cone)).to_dict())
     elif args.command == "batch":
         _print_json(calculate_batch(args.recipe, args.size, args.unit))
     elif args.command == "substitutions":

--- a/openglaze_cli.py
+++ b/openglaze_cli.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""OpenGlaze command-line interface."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from core.chemistry.batch import calculate_batch
+from core.chemistry.substitutions import suggest_substitutions
+from core.chemistry.umf import calculate_umf
+
+
+def _print_json(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _project_brief() -> dict[str, Any]:
+    return {
+        "name": "OpenGlaze",
+        "summary": "Open-source ceramic glaze calculator, UMF analyzer, CTE estimator, recipe manager, and self-hosted studio tool.",
+        "surfaces": {
+            "web": "python server.py",
+            "cli": "python -m openglaze_cli",
+            "mcp": "python -m openglaze_mcp",
+            "skill": "skills/openglaze/SKILL.md",
+        },
+        "core_workflows": [
+            "calculate UMF and oxide ratios from glaze recipes",
+            "estimate thermal expansion and surface character",
+            "scale recipes into practical test batches",
+            "suggest substitutions for unavailable materials",
+        ],
+        "guardrail": "Computational glaze analysis guides test tiles; it does not replace real firings or food-safety validation.",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="OpenGlaze CLI for ceramic glaze analysis."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("brief", help="Print a project and agent-surface brief.")
+
+    umf = subparsers.add_parser("umf", help="Calculate UMF and CTE for a recipe.")
+    umf.add_argument(
+        "--recipe",
+        required=True,
+        help="Recipe string, e.g. 'Custer Feldspar 45, Silica 25, Whiting 18, EPK 12'.",
+    )
+    umf.add_argument(
+        "--cone", type=int, default=10, help="Firing cone. Defaults to 10."
+    )
+
+    batch = subparsers.add_parser("batch", help="Scale a recipe to a test batch.")
+    batch.add_argument("--recipe", required=True, help="Recipe string to scale.")
+    batch.add_argument("--size", type=float, required=True, help="Target batch size.")
+    batch.add_argument(
+        "--unit", default="grams", help="grams or pounds. Defaults to grams."
+    )
+
+    substitutions = subparsers.add_parser(
+        "substitutions", help="Suggest material substitutions for a recipe."
+    )
+    substitutions.add_argument(
+        "--recipe", required=True, help="Recipe string to analyze."
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "brief":
+        _print_json(_project_brief())
+    elif args.command == "umf":
+        _print_json(calculate_umf(args.recipe, cone=args.cone).to_dict())
+    elif args.command == "batch":
+        _print_json(calculate_batch(args.recipe, args.size, args.unit))
+    elif args.command == "substitutions":
+        _print_json(suggest_substitutions(args.recipe).to_dict())
+
+
+if __name__ == "__main__":
+    main()

--- a/openglaze_mcp.py
+++ b/openglaze_mcp.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""OpenGlaze stdio MCP server."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from core.chemistry.batch import calculate_batch
+from core.chemistry.substitutions import suggest_substitutions
+from core.chemistry.umf import calculate_umf
+from openglaze_cli import _project_brief
+
+PROTOCOL_VERSION = "2024-11-05"
+
+
+def analyze_glaze_recipe(args: dict[str, Any]) -> dict[str, Any]:
+    recipe = str(args.get("recipe") or "").strip()
+    if not recipe:
+        raise ValueError("Provide recipe.")
+    cone = int(args.get("cone") or 10)
+    return calculate_umf(recipe, cone=cone).to_dict()
+
+
+def scale_glaze_batch(args: dict[str, Any]) -> dict[str, Any]:
+    recipe = str(args.get("recipe") or "").strip()
+    if not recipe:
+        raise ValueError("Provide recipe.")
+    size = float(args.get("size") or 0)
+    if size <= 0:
+        raise ValueError("Provide a positive size.")
+    return calculate_batch(recipe, size, str(args.get("unit") or "grams"))
+
+
+def suggest_material_substitutions(args: dict[str, Any]) -> dict[str, Any]:
+    recipe = str(args.get("recipe") or "").strip()
+    if not recipe:
+        raise ValueError("Provide recipe.")
+    return suggest_substitutions(recipe).to_dict()
+
+
+TOOLS = {
+    "openglaze_project_brief": {
+        "description": "Return OpenGlaze project identity, surfaces, and safety guardrail.",
+        "handler": lambda _args: _project_brief(),
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    "analyze_glaze_recipe": {
+        "description": "Calculate UMF, ratios, surface prediction, warnings, and CTE for a glaze recipe.",
+        "handler": analyze_glaze_recipe,
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "recipe": {"type": "string"},
+                "cone": {"type": "integer", "default": 10},
+            },
+            "required": ["recipe"],
+        },
+    },
+    "scale_glaze_batch": {
+        "description": "Scale a glaze recipe to a target batch size.",
+        "handler": scale_glaze_batch,
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "recipe": {"type": "string"},
+                "size": {"type": "number"},
+                "unit": {"type": "string", "default": "grams"},
+            },
+            "required": ["recipe", "size"],
+        },
+    },
+    "suggest_material_substitutions": {
+        "description": "Suggest substitutes for unknown or unavailable recipe materials.",
+        "handler": suggest_material_substitutions,
+        "inputSchema": {
+            "type": "object",
+            "properties": {"recipe": {"type": "string"}},
+            "required": ["recipe"],
+        },
+    },
+}
+
+
+def handle_tool_call(
+    name: str, arguments: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    if name not in TOOLS:
+        raise ValueError(f"Unknown tool: {name}")
+    return TOOLS[name]["handler"](arguments or {})
+
+
+def _tool_list() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": name,
+            "description": spec["description"],
+            "inputSchema": spec["inputSchema"],
+        }
+        for name, spec in TOOLS.items()
+    ]
+
+
+def _response(message_id: Any, result: dict[str, Any]) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": message_id, "result": result}
+
+
+def _error(message_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "error": {"code": code, "message": message},
+    }
+
+
+def handle_message(message: dict[str, Any]) -> dict[str, Any] | None:
+    method = message.get("method")
+    message_id = message.get("id")
+    params = message.get("params") or {}
+
+    if message_id is None:
+        return None
+    if method == "initialize":
+        return _response(
+            message_id,
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "openglaze", "version": "0.1.0"},
+            },
+        )
+    if method == "tools/list":
+        return _response(message_id, {"tools": _tool_list()})
+    if method == "tools/call":
+        try:
+            result = handle_tool_call(
+                params.get("name", ""), params.get("arguments") or {}
+            )
+            return _response(
+                message_id,
+                {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]},
+            )
+        except ValueError as exc:
+            return _error(message_id, -32602, str(exc))
+    return _error(message_id, -32601, f"Unsupported method: {method}")
+
+
+def main() -> None:
+    for line in sys.stdin:
+        if not line.strip():
+            continue
+        try:
+            reply = handle_message(json.loads(line))
+        except json.JSONDecodeError as exc:
+            reply = _error(None, -32700, f"Invalid JSON: {exc}")
+        if reply is not None:
+            sys.stdout.write(json.dumps(reply) + "\n")
+            sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/openglaze_mcp.py
+++ b/openglaze_mcp.py
@@ -10,7 +10,7 @@ from typing import Any
 from core.chemistry.batch import calculate_batch
 from core.chemistry.substitutions import suggest_substitutions
 from core.chemistry.umf import calculate_umf
-from openglaze_cli import _project_brief
+from openglaze_cli import _parse_cone, _project_brief
 
 PROTOCOL_VERSION = "2024-11-05"
 
@@ -19,7 +19,7 @@ def analyze_glaze_recipe(args: dict[str, Any]) -> dict[str, Any]:
     recipe = str(args.get("recipe") or "").strip()
     if not recipe:
         raise ValueError("Provide recipe.")
-    cone = int(args.get("cone") or 10)
+    cone = _parse_cone(args.get("cone") or 10)
     return calculate_umf(recipe, cone=cone).to_dict()
 
 
@@ -53,7 +53,11 @@ TOOLS = {
             "type": "object",
             "properties": {
                 "recipe": {"type": "string"},
-                "cone": {"type": "integer", "default": 10},
+                "cone": {
+                    "type": ["integer", "string"],
+                    "default": 10,
+                    "description": "Firing cone. Use strings like '04' to preserve low-fire cone identity.",
+                },
             },
             "required": ["recipe"],
         },

--- a/skills/openglaze/SKILL.md
+++ b/skills/openglaze/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: openglaze
+description: Use OpenGlaze for ceramic glaze recipe analysis, UMF calculation, CTE estimation, batch scaling, material substitution research, and self-hosted pottery studio workflows. Trigger when an agent needs computational glaze chemistry help with real recipe strings.
+---
+
+# OpenGlaze
+
+Use this skill when a task involves ceramic glaze recipes, UMF analysis, CTE risk, test-batch scaling, material substitutions, or OpenGlaze project work.
+
+## Start Here
+
+- Read `../../README.md` for setup, self-hosting, and safety framing.
+- Use the CLI for direct local calculations: `python -m openglaze_cli`.
+- Use the MCP server when an agent host should call glaze tools directly: `python -m openglaze_mcp`.
+- Core chemistry lives under `../../core/chemistry/`.
+
+## Workflow
+
+1. Normalize the recipe string before analysis. Include material names and percentages.
+2. Use `umf` or the `analyze_glaze_recipe` MCP tool before making chemistry claims.
+3. Check `limit_warnings`, `missing_materials`, `thermal_expansion`, and `surface_confidence`.
+4. Use batch scaling only after the recipe parses successfully.
+5. Treat substitutions as test-tile candidates, not one-shot replacements.
+
+## CLI Examples
+
+```bash
+python -m openglaze_cli brief
+python -m openglaze_cli umf --recipe "Custer Feldspar 45, Silica 25, Whiting 18, EPK 12" --cone 10
+python -m openglaze_cli batch --recipe "Custer Feldspar 45, Silica 25, Whiting 18, EPK 12" --size 500
+python -m openglaze_cli substitutions --recipe "Custer Feldspar 50, Unobtainium 25, Silica 25"
+```
+
+## MCP Setup
+
+```json
+{
+  "mcpServers": {
+    "openglaze": {
+      "command": "python",
+      "args": ["-m", "openglaze_mcp"]
+    }
+  }
+}
+```
+
+## Guardrails
+
+- Do not present computed glaze fit as a substitute for fired test tiles.
+- Do not make food-safety guarantees from UMF, CTE, or recipe data alone.
+- When parsing fails or materials are missing, say so directly before offering alternatives.
+- Keep advice practical for potters: next test, expected risk, and what to observe.

--- a/skills/openglaze/agents/openai.yaml
+++ b/skills/openglaze/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "OpenGlaze"
+  short_description: "Analyze ceramic glaze recipes and batches"
+  default_prompt: "Use $openglaze to calculate UMF, CTE, and batch guidance for this glaze recipe."
+
+policy:
+  allow_implicit_invocation: true

--- a/tests/test_agent_surfaces.py
+++ b/tests/test_agent_surfaces.py
@@ -1,0 +1,33 @@
+"""Tests for OpenGlaze CLI, MCP, and public skill surfaces."""
+
+from pathlib import Path
+
+from openglaze_mcp import handle_message, handle_tool_call
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_mcp_analyzes_glaze_recipe():
+    result = handle_tool_call(
+        "analyze_glaze_recipe",
+        {"recipe": "Custer Feldspar 45, Silica 25, Whiting 18, EPK 12", "cone": 10},
+    )
+
+    assert result["success"] is True
+    assert result["thermal_expansion"] is not None
+
+
+def test_mcp_lists_tools():
+    response = handle_message({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+
+    assert response is not None
+    assert any(
+        tool["name"] == "scale_glaze_batch" for tool in response["result"]["tools"]
+    )
+
+
+def test_public_skill_exists():
+    skill = ROOT / "skills" / "openglaze" / "SKILL.md"
+
+    assert skill.exists()
+    assert "python -m openglaze_mcp" in skill.read_text()

--- a/tests/test_agent_surfaces.py
+++ b/tests/test_agent_surfaces.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from core.chemistry.umf import get_limit_formulas
 from openglaze_mcp import handle_message, handle_tool_call
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -31,3 +32,13 @@ def test_public_skill_exists():
 
     assert skill.exists()
     assert "python -m openglaze_mcp" in skill.read_text()
+
+
+def test_agent_surfaces_preserve_low_fire_cone_values():
+    result = handle_tool_call(
+        "analyze_glaze_recipe",
+        {"recipe": "Ferro Frit 3124 40, Silica 20, EPK 20, Whiting 20", "cone": "04"},
+    )
+
+    assert result["cone"] == "04"
+    assert get_limit_formulas("04") != get_limit_formulas(4)


### PR DESCRIPTION
## Summary
- add OpenGlaze CLI commands for brief, UMF, batch scaling, and substitutions
- add a stdio MCP server exposing glaze-analysis tools
- add public skill metadata and docs/tests

## Verification
- python3 -m openglaze_cli umf --recipe "Custer Feldspar 45, Silica 25, Whiting 18, EPK 12" --cone 10
- python3 -m pytest tests/test_agent_surfaces.py -q
- python3 -m pytest -q

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/openglaze/pr/116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783099128&installation_id=130430723&pr_number=116&repository=KyaniteLabs%2Fopenglaze&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fopenglaze%2Fpull%2F116&signature=f12253f612ed67d08e9a489922b33aa7db029b921731a9684cc0f8ab8d1d1716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->